### PR TITLE
Fix runtime error caused by missing arguments in dispatcher

### DIFF
--- a/erdpy/dispatcher/transactions/queue.py
+++ b/erdpy/dispatcher/transactions/queue.py
@@ -137,7 +137,9 @@ class TransactionQueue:
                 tx.get("value"),
                 tx.get("data"),
                 tx.get("gasPrice"),
-                tx.get("gasLimit")
+                tx.get("gasLimit"),
+                tx.get("chain"),
+                tx.get("version")
             )
             # increment nonce
             nonce += 1


### PR DESCRIPTION
When trying to dispatch transactions using the dispatcher the following error is currently thrown.

![image](https://user-images.githubusercontent.com/6072971/126003607-d2d62a40-d108-4d16-84a9-922bec97da45.png)


This pr attempts to fix that :)

I made it on a very short notice so it's not 100% tested, but the change seemed simple enough :)

Keep up the great work!