### PR TITLE
Simplified regex strings

### DIFF
--- a/erdpy/ide/static/app/main.js
+++ b/erdpy/ide/static/app/main.js
@@ -1,6 +1,6 @@
 _.templateSettings = {
-    interpolate: /\[\[=(.+?)\]\]/g,
-    evaluate: /\[\[(.+?)\]\]/g,
+    interpolate: /\[\[=(.+?)]]/g,
+    evaluate: /\[\[(.+?)]]/g,
 };
 
 var app = {};


### PR DESCRIPTION
The ending square brackets shouldn't be escaped because they have a special meaning only if they match some starting square brackets (but this is not the case here). So, they are normal chars.