### PR TITLE
Extra config args

### DIFF
--- a/erdpy/cli.py
+++ b/erdpy/cli.py
@@ -21,7 +21,7 @@ import erdpy.cli_validators
 import erdpy.cli_wallet
 import erdpy.cli_delagation
 import erdpy.cli_dns
-from erdpy import errors, scope
+from erdpy import config, errors, scope
 from erdpy._version import __version__
 
 logger = logging.getLogger("cli")
@@ -43,7 +43,8 @@ def _do_main():
     scope.initialize()
 
     parser = setup_parser()
-    args = parser.parse_args()
+    argv_with_config_args = config.add_config_args(sys.argv[1:])
+    args = parser.parse_args(argv_with_config_args)
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)

--- a/erdpy/cli.py
+++ b/erdpy/cli.py
@@ -32,10 +32,11 @@ def main():
         _do_main()
     except errors.KnownError as err:
         logger.critical(err.get_pretty())
-        sys.exit(1)
+        return 1
     except KeyboardInterrupt:
         print("erdpy process killed by user.")
-        sys.exit(1)
+        return 1
+    return 0
 
 
 def _do_main():
@@ -113,4 +114,5 @@ COMMAND GROUPS summary
 
 
 if __name__ == "__main__":
-    main()
+    ret = main()
+    sys.exit(ret)

--- a/erdpy/cli.py
+++ b/erdpy/cli.py
@@ -42,8 +42,8 @@ def _do_main():
     logging.basicConfig(level=logging.INFO)
     scope.initialize()
 
-    parser = setup_parser()
     argv_with_config_args = config.add_config_args(sys.argv[1:])
+    parser = setup_parser(argv_with_config_args)
     args = parser.parse_args(argv_with_config_args)
 
     if args.verbose:
@@ -57,7 +57,7 @@ def _do_main():
         args.func(args)
 
 
-def setup_parser():
+def setup_parser(args: List[str] = sys.argv[1:]):
     parser = ArgumentParser(
         prog="erdpy",
         usage="erdpy [-h] [-v] [--verbose] COMMAND-GROUP [-h] COMMAND ...",
@@ -83,23 +83,23 @@ https://docs.elrond.com/tools/erdpy.
     subparsers = parser.add_subparsers()
     commands: List[Any] = []
 
-    commands.append(erdpy.cli_contracts.setup_parser(subparsers))
-    commands.append(erdpy.cli_transactions.setup_parser(subparsers))
-    commands.append(erdpy.cli_validators.setup_parser(subparsers))
+    commands.append(erdpy.cli_contracts.setup_parser(args, subparsers))
+    commands.append(erdpy.cli_transactions.setup_parser(args, subparsers))
+    commands.append(erdpy.cli_validators.setup_parser(args, subparsers))
     commands.append(erdpy.cli_accounts.setup_parser(subparsers))
     commands.append(erdpy.cli_ledger.setup_parser(subparsers))
-    commands.append(erdpy.cli_wallet.setup_parser(subparsers))
+    commands.append(erdpy.cli_wallet.setup_parser(args, subparsers))
     commands.append(erdpy.cli_network.setup_parser(subparsers))
     commands.append(erdpy.cli_cost.setup_parser(subparsers))
-    commands.append(erdpy.cli_dispatcher.setup_parser(subparsers))
+    commands.append(erdpy.cli_dispatcher.setup_parser(args, subparsers))
     commands.append(erdpy.cli_blockatlas.setup_parser(subparsers))
     commands.append(erdpy.cli_deps.setup_parser(subparsers))
     commands.append(erdpy.cli_config.setup_parser(subparsers))
     commands.append(erdpy.cli_block.setup_parser(subparsers))
-    commands.append(erdpy.cli_testnet.setup_parser(subparsers))
+    commands.append(erdpy.cli_testnet.setup_parser(args, subparsers))
     commands.append(erdpy.cli_data.setup_parser(subparsers))
-    commands.append(erdpy.cli_delagation.setup_parser(subparsers))
-    commands.append(erdpy.cli_dns.setup_parser(subparsers))
+    commands.append(erdpy.cli_delagation.setup_parser(args, subparsers))
+    commands.append(erdpy.cli_dns.setup_parser(args, subparsers))
 
     parser.epilog = """
 ----------------------

--- a/erdpy/cli_contracts.py
+++ b/erdpy/cli_contracts.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any
+from typing import Any, List
 
 from pathlib import Path
 
@@ -14,7 +14,7 @@ from erdpy.transactions import Transaction
 logger = logging.getLogger("cli.contracts")
 
 
-def setup_parser(subparsers: Any) -> Any:
+def setup_parser(args: List[str], subparsers: Any) -> Any:
     parser = cli_shared.add_group_subparser(subparsers, "contract", "Build, deploy and interact with Smart Contracts")
     subparsers = parser.add_subparsers()
 
@@ -50,9 +50,9 @@ def setup_parser(subparsers: Any) -> Any:
     _add_project_or_bytecode_arg(sub)
     _add_metadata_arg(sub)
     cli_shared.add_outfile_arg(sub)
-    cli_shared.add_wallet_args(sub)
+    cli_shared.add_wallet_args(args, sub)
     cli_shared.add_proxy_arg(sub)
-    cli_shared.add_tx_args(sub, with_receiver=False, with_data=False)
+    cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False)
     _add_arguments_arg(sub)
     sub.add_argument("--wait-result", action="store_true", default=False,
                      help="signal to wait for the transaction result - only valid if --send is set")
@@ -65,9 +65,9 @@ def setup_parser(subparsers: Any) -> Any:
     sub = cli_shared.add_command_subparser(subparsers, "contract", "call", "Interact with a Smart Contract (execute function).")
     _add_contract_arg(sub)
     cli_shared.add_outfile_arg(sub)
-    cli_shared.add_wallet_args(sub)
+    cli_shared.add_wallet_args(args, sub)
     cli_shared.add_proxy_arg(sub)
-    cli_shared.add_tx_args(sub, with_receiver=False, with_data=False)
+    cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False)
     _add_function_arg(sub)
     _add_arguments_arg(sub)
     sub.add_argument("--wait-result", action="store_true", default=False,
@@ -83,9 +83,9 @@ def setup_parser(subparsers: Any) -> Any:
     cli_shared.add_outfile_arg(sub)
     _add_project_or_bytecode_arg(sub)
     _add_metadata_arg(sub)
-    cli_shared.add_wallet_args(sub)
+    cli_shared.add_wallet_args(args, sub)
     cli_shared.add_proxy_arg(sub)
-    cli_shared.add_tx_args(sub, with_receiver=False, with_data=False)
+    cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False)
     _add_arguments_arg(sub)
     sub.add_argument("--wait-result", action="store_true", default=False,
                      help="signal to wait for the transaction result - only valid if --send is set")

--- a/erdpy/cli_delagation.py
+++ b/erdpy/cli_delagation.py
@@ -1,6 +1,6 @@
 import binascii
 import sys
-from typing import Any
+from typing import Any, List
 
 from erdpy import cli_shared, errors, utils
 from erdpy.accounts import Address
@@ -9,7 +9,7 @@ from erdpy.proxy import ElrondProxy
 from erdpy.transactions import do_prepare_transaction
 
 
-def setup_parser(subparsers: Any) -> Any:
+def setup_parser(args: List[str], subparsers: Any) -> Any:
     parser = cli_shared.add_group_subparser(subparsers, "staking-provider", "Staking provider omnitool")
     subparsers = parser.add_subparsers()
 
@@ -17,7 +17,7 @@ def setup_parser(subparsers: Any) -> Any:
     sub = cli_shared.add_command_subparser(subparsers, "staking-provider", "create-new-delegation-contract",
                                            "Create a new delegation system smart contract, transferred value must be"
                                            "greater than baseIssuingCost + min deposit value")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.add_argument("--total-delegation-cap", required=True, help="the total delegation contract capacity")
     sub.add_argument("--service-fee", required=True, help="the delegation contract service fee")
     sub.set_defaults(func=do_create_delegation_contract)
@@ -37,7 +37,7 @@ def setup_parser(subparsers: Any) -> Any:
     sub.add_argument("--validators-file", required=True, help="a JSON file describing the Nodes")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
     sub.add_argument("--using-delegation-manager", action="store_true", required=False, help="whether delegation contract was created using the Delegation Manager")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=add_new_nodes)
 
     # remove nodes
@@ -45,7 +45,7 @@ def setup_parser(subparsers: Any) -> Any:
                                            "Remove nodes must be called by the contract owner")
     sub.add_argument("--bls-keys", required=True, help="a list with the bls keys of the nodes")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=remove_nodes)
 
     # stake nodes
@@ -53,7 +53,7 @@ def setup_parser(subparsers: Any) -> Any:
                                            "Stake nodes must be called by the contract owner")
     sub.add_argument("--bls-keys", required=True, help="a list with the bls keys of the nodes")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=stake_nodes)
 
     # unbond nodes
@@ -61,7 +61,7 @@ def setup_parser(subparsers: Any) -> Any:
                                            "Unbond nodes must be called by the contract owner")
     sub.add_argument("--bls-keys", required=True, help="a list with the bls keys of the nodes")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=unbond_nodes)
 
     # unstake nodes
@@ -69,7 +69,7 @@ def setup_parser(subparsers: Any) -> Any:
                                            "Unstake nodes must be called by the contract owner")
     sub.add_argument("--bls-keys", required=True, help="a list with the bls keys of the nodes")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=unstake_nodes)
 
     # unjail nodes
@@ -77,7 +77,7 @@ def setup_parser(subparsers: Any) -> Any:
                                            "Unjail nodes must be called by the contract owner")
     sub.add_argument("--bls-keys", required=True, help="a list with the bls keys of the nodes")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=unjail_nodes)
 
     # change service fee
@@ -85,7 +85,7 @@ def setup_parser(subparsers: Any) -> Any:
                                            "Change service fee must be called by the contract owner")
     sub.add_argument("--service-fee", required=True, help="new service fee value")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=change_service_fee)
 
     # modify total delegation cap
@@ -93,31 +93,31 @@ def setup_parser(subparsers: Any) -> Any:
                                            "Modify delegation cap must be called by the contract owner")
     sub.add_argument("--delegation-cap", required=True, help="new delegation contract capacity")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=modify_delegation_cap)
 
     # set automatic activation
     sub = cli_shared.add_command_subparser(subparsers, "staking-provider", "automatic-activation",
                                            "Automatic activation must be called by the contract owner")
 
-    sub.add_argument("--set", action="store_true", required=not (utils.is_arg_present("--unset", sys.argv)),
+    sub.add_argument("--set", action="store_true", required=not (utils.is_arg_present(args, "--unset")),
                      help="set automatic activation True")
-    sub.add_argument("--unset", action="store_true", required=not (utils.is_arg_present("--set", sys.argv)),
+    sub.add_argument("--unset", action="store_true", required=not (utils.is_arg_present(args, "--set")),
                      help="set automatic activation False")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=automatic_activation)
 
     # set redelegate cap
     sub = cli_shared.add_command_subparser(subparsers, "staking-provider", "redelegate-cap",
                                            "Redelegate cap must be called by the contract owner")
 
-    sub.add_argument("--set", action="store_true", required=not (utils.is_arg_present("--unset", sys.argv)),
+    sub.add_argument("--set", action="store_true", required=not (utils.is_arg_present(args, "--unset")),
                      help="set redelegate cap True")
-    sub.add_argument("--unset", action="store_true", required=not (utils.is_arg_present("--set", sys.argv)),
+    sub.add_argument("--unset", action="store_true", required=not (utils.is_arg_present(args, "--set")),
                      help="set redelegate cap False")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=redelegate_cap)
 
     # set metadata
@@ -128,14 +128,14 @@ def setup_parser(subparsers: Any) -> Any:
     sub.add_argument("--website", required=True, help="website field in staking provider metadata")
     sub.add_argument("--identifier", required=True, help="identifier field in staking provider metadata")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=set_metadata)
 
 
-def _add_common_arguments(sub: Any):
+def _add_common_arguments(args: List[str], sub: Any):
     cli_shared.add_proxy_arg(sub)
-    cli_shared.add_wallet_args(sub)
-    cli_shared.add_tx_args(sub, with_receiver=False, with_data=False, with_estimate_gas=True)
+    cli_shared.add_wallet_args(args, sub)
+    cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False, with_estimate_gas=True)
     cli_shared.add_broadcast_args(sub, relay=False)
     cli_shared.add_outfile_arg(sub, what="signed transaction, hash")
 

--- a/erdpy/cli_dispatcher.py
+++ b/erdpy/cli_dispatcher.py
@@ -1,28 +1,28 @@
 from erdpy.dispatcher.transactions.queue import TransactionQueue
 import logging
-from typing import Any
+from typing import Any, List
 
 from erdpy import cli_shared
 
 logger = logging.getLogger("cli.dispatcher")
 
 
-def setup_parser(subparsers: Any) -> Any:
+def setup_parser(args: List[str], subparsers: Any) -> Any:
     parser = cli_shared.add_group_subparser(subparsers, "dispatcher", "Enqueue transactions, then bulk dispatch them")
     subparsers = parser.add_subparsers()
 
     sub = cli_shared.add_command_subparser(subparsers, "dispatcher", "enqueue", "Enqueue a transaction")
-    cli_shared.add_tx_args(sub, with_nonce=False)
+    cli_shared.add_tx_args(args, sub, with_nonce=False)
     sub.set_defaults(func=enqueue_transaction)
 
     sub = cli_shared.add_command_subparser(subparsers, "dispatcher", "dispatch", "Dispatch queued transactions")
     cli_shared.add_proxy_arg(sub)
-    cli_shared.add_wallet_args(sub)
+    cli_shared.add_wallet_args(args, sub)
     sub.set_defaults(func=dispatch_transactions)
 
     sub = cli_shared.add_command_subparser(subparsers, "dispatcher", "dispatch-continuously", "Continuously dispatch queued transactions")
     cli_shared.add_proxy_arg(sub)
-    cli_shared.add_wallet_args(sub)
+    cli_shared.add_wallet_args(args, sub)
     sub.add_argument("--interval", required=True, help="the interval to retrieve transactions from the queue, in seconds")
     sub.set_defaults(func=dispatch_transactions_continuously)
 

--- a/erdpy/cli_dns.py
+++ b/erdpy/cli_dns.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 from prettytable import PrettyTable
 
 from erdpy import cli_shared
@@ -7,16 +7,16 @@ from erdpy.accounts import Address
 from erdpy.proxy.core import ElrondProxy
 
 
-def setup_parser(subparsers: Any) -> Any:
+def setup_parser(args: List[str], subparsers: Any) -> Any:
     parser = cli_shared.add_group_subparser(subparsers, "dns", "Operations related to the Domain Name Service")
     subparsers = parser.add_subparsers()
 
     sub = cli_shared.add_command_subparser(subparsers, "dns", "register", "Send a register transaction to the appropriate DNS contract from given user and with given name")
     cli_shared.add_outfile_arg(sub)
     cli_shared.add_broadcast_args(sub, relay=True)
-    cli_shared.add_wallet_args(sub)
+    cli_shared.add_wallet_args(args, sub)
     cli_shared.add_proxy_arg(sub)
-    cli_shared.add_tx_args(sub, with_receiver=False, with_data=False)
+    cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False)
     sub.add_argument("--name", help="the name to register")
     sub.set_defaults(func=register)
 

--- a/erdpy/cli_shared.py
+++ b/erdpy/cli_shared.py
@@ -49,9 +49,9 @@ def add_command_subparser(subparsers: Any, group: str, command: str, description
     )
 
 
-def add_tx_args(sub: Any, with_nonce: bool = True, with_receiver: bool = True, with_data: bool = True, with_estimate_gas: bool = False):
+def add_tx_args(args: List[str], sub: Any, with_nonce: bool = True, with_receiver: bool = True, with_data: bool = True, with_estimate_gas: bool = False):
     if with_nonce:
-        sub.add_argument("--nonce", type=int, required=not("--recall-nonce" in sys.argv), help="# the nonce for the transaction")
+        sub.add_argument("--nonce", type=int, required=not("--recall-nonce" in args), help="# the nonce for the transaction")
         sub.add_argument("--recall-nonce", action="store_true", default=False, help="⭮ whether to recall the nonce when creating the transaction (default: %(default)s)")
 
     if with_receiver:
@@ -59,7 +59,7 @@ def add_tx_args(sub: Any, with_nonce: bool = True, with_receiver: bool = True, w
         sub.add_argument("--receiver-username", required=False, help="🖄 the username of the receiver")
 
     sub.add_argument("--gas-price", default=config.DEFAULT_GAS_PRICE, help="⛽ the gas price (default: %(default)d)")
-    sub.add_argument("--gas-limit", required=not("--estimate-gas" in sys.argv), help="⛽ the gas limit")
+    sub.add_argument("--gas-limit", required=not("--estimate-gas" in args), help="⛽ the gas limit")
     if with_estimate_gas:
         sub.add_argument("--estimate-gas", action="store_true", default=False, help="⛽ whether to estimate the gas limit (default: %(default)d)")
 
@@ -73,12 +73,12 @@ def add_tx_args(sub: Any, with_nonce: bool = True, with_receiver: bool = True, w
     sub.add_argument("--options", type=int, default=0, help="the transaction options (default: 0)")
 
 
-def add_wallet_args(sub: Any):
-    sub.add_argument("--pem", required=check_if_sign_method_required("--pem"), help="🔑 the PEM file, if keyfile not provided")
+def add_wallet_args(args: List[str], sub: Any):
+    sub.add_argument("--pem", required=check_if_sign_method_required(args, "--pem"), help="🔑 the PEM file, if keyfile not provided")
     sub.add_argument("--pem-index", default=0, help="🔑 the index in the PEM file (default: %(default)s)")
-    sub.add_argument("--keyfile", required=check_if_sign_method_required("--keyfile"), help="🔑 a JSON keyfile, if PEM not provided")
-    sub.add_argument("--passfile", required=(utils.is_arg_present("--keyfile", sys.argv)), help="🔑 a file containing keyfile's password, if keyfile provided")
-    sub.add_argument("--ledger", action="store_true", required=check_if_sign_method_required("--ledger"), default=False, help="🔐 bool flag for signing transaction using ledger")
+    sub.add_argument("--keyfile", required=check_if_sign_method_required(args, "--keyfile"), help="🔑 a JSON keyfile, if PEM not provided")
+    sub.add_argument("--passfile", required=(utils.is_arg_present(args, "--keyfile")), help="🔑 a file containing keyfile's password, if keyfile provided")
+    sub.add_argument("--ledger", action="store_true", required=check_if_sign_method_required(args, "--ledger"), default=False, help="🔐 bool flag for signing transaction using ledger")
     sub.add_argument("--ledger-account-index", type=int, default=0, help="🔐 the index of the account when using Ledger")
     sub.add_argument("--ledger-address-index", type=int, default=0, help="🔐 the index of the address when using Ledger")
     sub.add_argument("--sender-username", required=False, help="🖄 the username of the sender")
@@ -148,7 +148,7 @@ def send_or_simulate(tx: Transaction, args: Any):
         utils.dump_out_json(response)
 
 
-def check_if_sign_method_required(checked_method: str) -> bool:
+def check_if_sign_method_required(args: List[str], checked_method: str) -> bool:
     methods = ["--pem", "--keyfile", "--ledger"]
     rest_of_methods = []
     for method in methods:
@@ -156,7 +156,7 @@ def check_if_sign_method_required(checked_method: str) -> bool:
             rest_of_methods.append(method)
 
     for method in rest_of_methods:
-        if utils.is_arg_present(method, sys.argv):
+        if utils.is_arg_present(args, method):
             return False
 
     return True

--- a/erdpy/cli_testnet.py
+++ b/erdpy/cli_testnet.py
@@ -1,12 +1,12 @@
 import logging
-from typing import Any
+from typing import Any, List
 
 from erdpy import cli_shared, testnet
 
 logger = logging.getLogger("cli.testnet")
 
 
-def setup_parser(subparsers: Any) -> Any:
+def setup_parser(args: List[str], subparsers: Any) -> Any:
     parser = cli_shared.add_group_subparser(
         subparsers,
         "testnet",

--- a/erdpy/cli_transactions.py
+++ b/erdpy/cli_transactions.py
@@ -1,5 +1,5 @@
 from argparse import FileType
-from typing import Any
+from typing import Any, List
 
 from erdpy import cli_shared, utils
 from erdpy.ledger.ledger_functions import do_get_ledger_address
@@ -7,12 +7,12 @@ from erdpy.proxy.core import ElrondProxy
 from erdpy.transactions import Transaction, do_prepare_transaction
 
 
-def setup_parser(subparsers: Any) -> Any:
+def setup_parser(args: List[str], subparsers: Any) -> Any:
     parser = cli_shared.add_group_subparser(subparsers, "tx", "Create and broadcast Transactions")
     subparsers = parser.add_subparsers()
 
     sub = cli_shared.add_command_subparser(subparsers, "tx", "new", "Create a new transaction")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     cli_shared.add_outfile_arg(sub, what="signed transaction, hash")
     cli_shared.add_broadcast_args(sub, relay=True)
     cli_shared.add_proxy_arg(sub)
@@ -40,9 +40,9 @@ def setup_parser(subparsers: Any) -> Any:
     return subparsers
 
 
-def _add_common_arguments(sub: Any):
-    cli_shared.add_wallet_args(sub)
-    cli_shared.add_tx_args(sub)
+def _add_common_arguments(args: List[str], sub: Any):
+    cli_shared.add_wallet_args(args, sub)
+    cli_shared.add_tx_args(args, sub)
     sub.add_argument("--data-file", type=FileType("r"), default=None, help="a file containing transaction data")
 
 

--- a/erdpy/cli_validators.py
+++ b/erdpy/cli_validators.py
@@ -1,53 +1,53 @@
 import sys
-from typing import Any
+from typing import Any, List
 
 from erdpy import cli_shared, validators, utils
 from erdpy.transactions import do_prepare_transaction
 
 
-def setup_parser(subparsers: Any) -> Any:
+def setup_parser(args: List[str], subparsers: Any) -> Any:
     parser = cli_shared.add_group_subparser(subparsers, "validator", "Stake, UnStake, UnBond, Unjail and other "
                                                                      "actions useful for "
                                                                      "Validators")
     subparsers = parser.add_subparsers()
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "stake", "Stake value into the Network")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.add_argument("--reward-address", default="", help="the reward address")
-    sub.add_argument("--validators-file", required=not (utils.is_arg_present("--top-up", sys.argv)),
+    sub.add_argument("--validators-file", required=not (utils.is_arg_present(args, "--top-up")),
                      help="a JSON file describing the Nodes")
     sub.add_argument("--top-up", action="store_true", default=False,
-                     required=not (utils.is_arg_present("--validators-file", sys.argv)), help="Stake value for top up")
+                     required=not (utils.is_arg_present(args, "--validators-file")), help="Stake value for top up")
     sub.set_defaults(func=do_stake)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "unstake", "Unstake value")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     _add_nodes_arg(sub)
     sub.set_defaults(func=do_unstake)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "unjail", "Unjail a Validator Node")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     _add_nodes_arg(sub)
     sub.set_defaults(func=do_unjail)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "unbond", "Unbond tokens for a bls key")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     _add_nodes_arg(sub)
     sub.set_defaults(func=do_unbond)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "change-reward-address",
                                            "Change the reward address")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.add_argument("--reward-address", required=True, help="the new reward address")
     sub.set_defaults(func=change_reward_address)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "claim", "Claim rewards")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=do_claim)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "unstake-nodes", "Unstake-nodes will unstake "
                                                                                      "nodes for provided bls keys")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     _add_nodes_arg(sub)
     sub.set_defaults(func=do_unstake_nodes)
 
@@ -56,29 +56,29 @@ def setup_parser(subparsers: Any) -> Any:
                                                                                       "greater than the existing "
                                                                                       "topUp value, it will unStake "
                                                                                       "one or several nodes)")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.add_argument("--unstake-value", default=0, help="the unstake value")
     sub.set_defaults(func=do_unstake_tokens)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "unbond-nodes", "It will unBond nodes")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     _add_nodes_arg(sub)
     sub.set_defaults(func=do_unbond_nodes)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "unbond-tokens", "It will unBond tokens, if "
                                                                                      "provided value is bigger that "
                                                                                      "topUp value will unBond nodes")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.add_argument("--unbond-value", default=0, help="the unbond value")
     sub.set_defaults(func=do_unbond_tokens)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "clean-registered-data", "Deletes duplicated keys "
                                                                                              "from registered data")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     sub.set_defaults(func=do_clean_registered_data)
 
     sub = cli_shared.add_command_subparser(subparsers, "validator", "restake-unstaked-nodes", "It will reStake UnStaked nodes")
-    _add_common_arguments(sub)
+    _add_common_arguments(args, sub)
     _add_nodes_arg(sub)
     sub.set_defaults(func=do_restake_unstaked_nodes)
 
@@ -86,10 +86,10 @@ def setup_parser(subparsers: Any) -> Any:
     return subparsers
 
 
-def _add_common_arguments(sub: Any):
+def _add_common_arguments(args: List[str], sub: Any):
     cli_shared.add_proxy_arg(sub)
-    cli_shared.add_wallet_args(sub)
-    cli_shared.add_tx_args(sub, with_receiver=False, with_data=False, with_estimate_gas=True)
+    cli_shared.add_wallet_args(args, sub)
+    cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False, with_estimate_gas=True)
     cli_shared.add_broadcast_args(sub, relay=False)
     cli_shared.add_outfile_arg(sub, what="signed transaction, hash")
 

--- a/erdpy/cli_wallet.py
+++ b/erdpy/cli_wallet.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, List
 
 from erdpy import cli_shared, wallet
 from erdpy.accounts import Account, Address
@@ -8,7 +8,7 @@ from erdpy.wallet import pem
 logger = logging.getLogger("cli.wallet")
 
 
-def setup_parser(subparsers: Any) -> Any:
+def setup_parser(args: List[str], subparsers: Any) -> Any:
     parser = cli_shared.add_group_subparser(
         subparsers,
         "wallet",

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -1,3 +1,5 @@
+from itertools import chain
+from logging import Logger
 import os.path
 from typing import Any, Dict
 
@@ -175,3 +177,27 @@ def write_file(data: Dict[str, Any]):
         utils.write_json_file(LOCAL_CONFIG_PATH, data)
     else:
         utils.write_json_file(CONFIG_PATH, data)
+
+
+def add_config_args(argv):
+    if len(argv) < 2:
+        return argv
+
+    func, subcommand, *_ = argv
+    config = read_file()
+    if func not in config:
+        return argv
+
+    extra_func = config[func]
+    if subcommand not in extra_func:
+        return argv
+
+    extra_args = []
+    for key, value in extra_func[subcommand].items():
+        extra_args.append(f'--{key}')
+        if value is True:
+            continue
+        extra_args.append(str(value))
+
+    print(f"Added extra args from erdpy.json: {argv + extra_args}")
+    return argv + extra_args

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -1,7 +1,7 @@
 from itertools import chain
 from logging import Logger
 import os.path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from erdpy import errors, utils
 
@@ -197,7 +197,11 @@ def add_config_args(argv):
         extra_args.append(f'--{key}')
         if value is True:
             continue
-        extra_args.append(str(value))
+        if isinstance(value, List):
+            for item in value:
+                extra_args.append(str(item))
+        else:
+            extra_args.append(str(value))
 
     # the verbose flag is an exception since it has to go before the command and subcommand
     # eg. erdpy --verbose contract deploy

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -180,20 +180,20 @@ def write_file(data: Dict[str, Any]):
 
 
 def add_config_args(argv):
-    if len(argv) < 2:
+    try:
+        func, subcommand, *_ = argv
+    except ValueError:
         return argv
 
-    func, subcommand, *_ = argv
     config = read_file()
-    if func not in config:
-        return argv
 
-    extra_func = config[func]
-    if subcommand not in extra_func:
+    try:
+        config_args = config[func][subcommand]
+    except KeyError:
         return argv
 
     extra_args = []
-    for key, value in extra_func[subcommand].items():
+    for key, value in config_args.items():
         extra_args.append(f'--{key}')
         if value is True:
             continue

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 from erdpy import errors, utils
 
 ROOT_FOLDER_NAME = "elrondsdk"
+LOCAL_CONFIG_PATH = os.path.join(os.getcwd(), "erdpy.json")
 CONFIG_PATH = os.path.expanduser("~/elrondsdk/erdpy.json")
 
 DEFAULT_GAS_PRICE = 1000000000
@@ -162,10 +163,15 @@ def get_defaults() -> Dict[str, Any]:
 
 
 def read_file() -> Dict[str, Any]:
-    if not os.path.isfile(CONFIG_PATH):
-        return dict()
-    return utils.read_json_file(CONFIG_PATH)
+    if os.path.isfile(LOCAL_CONFIG_PATH):
+        return utils.read_json_file(LOCAL_CONFIG_PATH)
+    if os.path.isfile(CONFIG_PATH):
+        return utils.read_json_file(CONFIG_PATH)
+    return dict()
 
 
 def write_file(data: Dict[str, Any]):
-    utils.write_json_file(CONFIG_PATH, data)
+    if os.path.isfile(LOCAL_CONFIG_PATH):
+        utils.write_json_file(LOCAL_CONFIG_PATH, data)
+    else:
+        utils.write_json_file(CONFIG_PATH, data)

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -184,14 +184,14 @@ def write_file(data: Dict[str, Any]):
 
 def add_config_args(argv):
     try:
-        func, subcommand, *_ = argv
+        command, subcommand, *_ = argv
     except ValueError:
         return argv
 
     config = read_file()
 
     try:
-        config_args = config[func][subcommand]
+        config_args = config[command][subcommand]
     except KeyError:
         return argv
 

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -182,7 +182,7 @@ def write_file(data: Dict[str, Any]):
     utils.write_json_file(config_path, data)
 
 
-def add_config_args(argv):
+def add_config_args(argv: List[str]) -> List[str]:
     try:
         command, subcommand, *_ = argv
     except ValueError:
@@ -200,12 +200,14 @@ def add_config_args(argv):
     return final_args
 
 
-def determine_final_args(argv, config_args):
+def determine_final_args(argv: List[str], config_args: Dict[str, Any]) -> List[str]:
     extra_args = []
     for key, value in config_args.items():
         key_arg = f'--{key}'
         # arguments from the command line override the config
         if key_arg in argv:
+            continue
+        if any(arg.startswith(f"{key_arg}=") for arg in argv):
             continue
         extra_args.append(key_arg)
         if value is True:

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -199,5 +199,14 @@ def add_config_args(argv):
             continue
         extra_args.append(str(value))
 
-    print(f"Added extra args from erdpy.json: {argv + extra_args}")
-    return argv + extra_args
+    # the verbose flag is an exception since it has to go before the command and subcommand
+    # eg. erdpy --verbose contract deploy
+    verbose_flag = '--verbose'
+    pre_args = []
+    if verbose_flag in extra_args:
+        extra_args.remove(verbose_flag)
+        pre_args = [verbose_flag]
+
+    final_args = pre_args + argv + extra_args
+    print(f"Added extra args from erdpy.json: {final_args}")
+    return final_args

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -194,7 +194,11 @@ def add_config_args(argv):
 
     extra_args = []
     for key, value in config_args.items():
-        extra_args.append(f'--{key}')
+        key_arg = f'--{key}'
+        # arguments from the command line override the config
+        if key_arg in argv:
+            continue
+        extra_args.append(key_arg)
         if value is True:
             continue
         if isinstance(value, List):
@@ -212,5 +216,5 @@ def add_config_args(argv):
         pre_args = [verbose_flag]
 
     final_args = pre_args + argv + extra_args
-    print(f"Added extra args from erdpy.json: {final_args}")
+    print(f"Found extra arguments in erdpy.json. Final arguments: {final_args}")
     return final_args

--- a/erdpy/utils.py
+++ b/erdpy/utils.py
@@ -195,7 +195,7 @@ def as_object(data: Object) -> Object:
     return data
 
 
-def is_arg_present(key: str, args: List[str]) -> bool:
+def is_arg_present(args: List[str], key: str) -> bool:
     for arg in args:
         if arg.find("--data") != -1:
             continue

--- a/erdpy/utils.py
+++ b/erdpy/utils.py
@@ -9,7 +9,7 @@ import sys
 import tarfile
 import zipfile
 from pathlib import Path
-from typing import Any, List, Union, Optional, cast, IO, Dict
+from typing import Any, AnyStr, List, Union, Optional, cast, IO, Dict
 
 import toml
 
@@ -78,30 +78,32 @@ def read_lines(file: str):
 # TODO delete this function, it is too generic
 # TODO find usages in legolas
 def read_file(f: Any, binary: bool = False) -> Union[str, bytes]:
-    try:
-        if isinstance(f, str) or isinstance(f, pathlib.PosixPath):
-            path = Path(f)
-            if binary:
-                return read_binary_file(path)
-            return read_text_file(path)
+    if isinstance(f, str) or isinstance(f, pathlib.PosixPath):
+        path = Path(f)
+        if binary:
+            return read_binary_file(path)
+        return read_text_file(path)
 
-        file = cast(IO, f)
-        result = file.read()
-        assert isinstance(result, str) or isinstance(result, bytes)
-        return result
-
-    except Exception as err:
-        raise errors.BadFile(f, err)
+    file = cast(IO, f)
+    result = file.read()
+    assert isinstance(result, str) or isinstance(result, bytes)
+    return result
 
 
 def read_binary_file(path: Path) -> bytes:
-    with open(path, 'rb') as binary_file:
-        return binary_file.read()
+    try:
+        with open(path, 'rb') as binary_file:
+            return binary_file.read()
+    except Exception as err:
+        raise errors.BadFile(str(path), err) from None
 
 
 def read_text_file(path: Path) -> str:
-    with open(path, 'r') as text_file:
-        return text_file.read()
+    try:
+        with open(path, 'r') as text_file:
+            return text_file.read()
+    except Exception as err:
+        raise errors.BadFile(str(path), err) from None
 
 
 def write_file(f: Any, text: str):


### PR DESCRIPTION
- Use local erdpy.json from the current directory, if available
- When running erdpy from the command line, the config file is checked for any default arguments
  - Replaced usages of `sys.argv` with an extra argument `args` so that the default arguments can be added from the config file first
  - Changed argument order for `is_arg_present` for consistency - `args` first
  - Note: arguments provided in the command line can override those in the config files
- Changes regarding exception handling:
  - Exceptions no longer print the entire stack trace
  - Wrapped the `FileNotFound` exception when reading files, which simplifies the error message