### PR TITLE
Fix #30 --project argument regression bug

### DIFF
--- a/erdpy/cli_contracts.py
+++ b/erdpy/cli_contracts.py
@@ -221,7 +221,7 @@ def dump_tx_and_result(tx: Any, result: Any, args: Any):
 
 
 def _prepare_contract(args: Any) -> SmartContract:
-    if len(args.bytecode):
+    if args.bytecode and len(args.bytecode):
         bytecode = utils.read_binary_file(Path(args.bytecode)).hex()
     else:
         project = load_project(args.project)


### PR DESCRIPTION
Using the latest version there is a regression bug in the contract deploy functionality because it doesn't correctly check the --bytecode argument and it's therefore impossible to use the --project argument

This fixes issue #30 