### PR TITLE
Fix regression bug for contract query

### DIFF
--- a/erdpy/contracts.py
+++ b/erdpy/contracts.py
@@ -8,13 +8,14 @@ from erdpy import config, constants, errors
 from erdpy.accounts import Account, Address
 from erdpy.interfaces import IElrondProxy
 from erdpy.transactions import Transaction
+from erdpy.utils import Object
 
 logger = logging.getLogger("contracts")
 
 HEX_PREFIX = "0X"
 
 
-class QueryResult:
+class QueryResult(Object):
     def __init__(self, as_base64: str, as_hex: str, as_number: int):
         self.base64 = as_base64
         self.hex = as_hex


### PR DESCRIPTION
Fixing the following error message that is thrown if a QueryResult object is getting serialized for display in the console.

File "/home/wagnerm/python3.9/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type QueryResult is not JSON serializable

It is caused because the following line only checks for inheritance of the Object class. 
https://github.com/ElrondNetwork/elrond-sdk-erdpy/blob/main/erdpy/utils.py#L32

Without this fix every call to `erdpy contract query ` fails.