### PR TITLE
Added ComputeRewardCheckpointEnableEpoch to config

### DIFF
--- a/erdpy/testnet/node_config_toml.py
+++ b/erdpy/testnet/node_config_toml.py
@@ -80,6 +80,7 @@ def patch_enable_epochs(data: ConfigDict, testnet_config: TestnetConfiguration):
     enable_epochs['GlobalMintBurnDisableEpoch'] = 0
     enable_epochs['ESDTTransferRoleEnableEpoch'] = 0
     enable_epochs['BuiltInFunctionOnMetaEnableEpoch'] = 0
+    enable_epochs['ComputeRewardCheckpointEnableEpoch'] = 5
 
     enable_epochs['MaxNodesChangeEnableEpoch'] = [
         {'EpochEnable': 0, 'MaxNumNodes': 36, 'NodesToShufflePerShard': 4},


### PR DESCRIPTION
Since the [enableEpochs.toml](https://github.com/ElrondNetwork/elrond-go/blob/master/cmd/node/config/enableEpochs.toml#L112) for the nodes was updated we need to update erdpy too.


Otherwise the user receives the following error message:
"ValueError: unrecognized configuration keys {'ComputeRewardCheckpointEnableEpoch'}"