### PR TITLE
fix: HOME env in erdpy-up

### DIFF
--- a/erdpy-up.py
+++ b/erdpy-up.py
@@ -182,7 +182,7 @@ def run_in_venv(args):
         del os.environ["PYTHONHOME"]
 
     process = subprocess.Popen(args, env={
-        "PATH": os.path.join(get_erdpy_path(), "bin"),
+        "PATH": os.path.join(get_erdpy_path(), "bin") + ":" + os.environ["PATH"],
         "VIRTUAL_ENV": get_erdpy_path()
     })
 


### PR DESCRIPTION
## Problem

`The 'make' utility is missing from PATH`, although I have it installed.

![image](https://user-images.githubusercontent.com/25898298/136131825-a5384e29-f9f3-41c1-ba97-92afe1da6492.png)
