### PR TITLE
Add check for gas limit too large

### DIFF
--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -12,6 +12,7 @@ GLOBAL_CONFIG_PATH = os.path.expanduser("~/elrondsdk/erdpy.json")
 DEFAULT_GAS_PRICE = 1000000000
 GAS_PER_DATA_BYTE = 1500
 MIN_GAS_LIMIT = 50000
+MAX_GAS_LIMIT = 600000000
 
 
 class MetaChainSystemSCsCost:

--- a/erdpy/errors.py
+++ b/erdpy/errors.py
@@ -144,6 +144,11 @@ class UnknownCipher(KnownError):
         super().__init__(f"Unknown cipher: {name}.")
 
 
+class GasLimitTooLarge(KnownError):
+    def __init__(self, current: int, limit: int):
+        super().__init__(f"The gas limit provided ({current}) exceeds the max gas limit of allowed for a transaction ({limit})")
+
+
 class InvalidKeystoreFilePassword(KnownError):
     def __init__(self):
         super().__init__("Provided keystore file password is invalid.")

--- a/erdpy/tests/test_wallet.py
+++ b/erdpy/tests/test_wallet.py
@@ -8,6 +8,7 @@ from typing import Any
 import nacl.encoding
 import nacl.signing
 from erdpy.accounts import Account, Address
+from erdpy.errors import GasLimitTooLarge
 from erdpy.tests.utils import MyTestCase
 from erdpy.transactions import Transaction
 from erdpy.wallet import (bip39seed_to_secret_key, generate_pair,
@@ -127,6 +128,21 @@ class WalletTestCase(MyTestCase):
         transaction.sign(self.alice)
 
         self.assertEqual("83efd1bc35790ecc220b0ed6ddd1fcb44af6653dd74e37b3a49dcc1f002a1b98b6f79779192cca68bdfefd037bc81f4fa606628b751023122191f8c062362805", transaction.signature)
+
+    def test_gas_limit_too_large(self):
+        # With data
+        transaction = Transaction()
+        transaction.nonce = 0
+        transaction.value = "0"
+        transaction.sender = "erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz"
+        transaction.receiver = "erd188nydpkagtpwvfklkl2tn0w6g40zdxkwfgwpjqc2a2m2n7ne9g8q2t22sr"
+        transaction.gasPrice = 200000000000000
+        transaction.gasLimit = 1500000000
+        transaction.data = "foo"
+        transaction.chainID = "chainID"
+        transaction.version = 1
+
+        self.assertRaises(GasLimitTooLarge, lambda: transaction.sign(self.alice))
 
     def test_generate_pair_pem(self):
         secret_key, pubkey = generate_pair()

--- a/erdpy/transactions.py
+++ b/erdpy/transactions.py
@@ -62,6 +62,7 @@ class Transaction(ITransaction):
         return base64.b64decode(self.__dict__.get(field, None)).decode()
 
     def sign(self, account: Account):
+        signing.validate_transaction(self)
         self.signature = signing.sign_transaction(self, account)
 
     def serialize(self) -> bytes:

--- a/erdpy/transactions.py
+++ b/erdpy/transactions.py
@@ -4,7 +4,7 @@ import logging
 from collections import OrderedDict
 from typing import Any, Dict, List, TextIO
 
-from erdpy import errors, utils
+from erdpy import config, errors, utils
 from erdpy.accounts import Account, Address
 from erdpy.interfaces import IElrondProxy, ITransaction
 from erdpy.ledger.config import compare_versions
@@ -62,8 +62,12 @@ class Transaction(ITransaction):
         return base64.b64decode(self.__dict__.get(field, None)).decode()
 
     def sign(self, account: Account):
-        signing.validate_transaction(self)
+        self.validate()
         self.signature = signing.sign_transaction(self, account)
+
+    def validate(self) -> None:
+        if self.gasLimit > config.MAX_GAS_LIMIT:
+            raise errors.GasLimitTooLarge(self.gasLimit, config.MAX_GAS_LIMIT)
 
     def serialize(self) -> bytes:
         dictionary = self.to_dictionary()

--- a/erdpy/wallet/signing.py
+++ b/erdpy/wallet/signing.py
@@ -4,8 +4,7 @@ from typing import Any
 
 import nacl.encoding
 import nacl.signing
-from erdpy import config, dependencies, myprocess, transactions
-from erdpy import errors
+from erdpy import dependencies, myprocess
 from erdpy.errors import CannotSignMessageWithBLSKey
 from erdpy.interfaces import IAccount, ITransaction
 
@@ -23,11 +22,6 @@ def sign_transaction(transaction: ITransaction, account: IAccount) -> str:
     assert isinstance(signature_hex, str)
 
     return signature_hex
-
-
-def validate_transaction(transaction: transactions.Transaction) -> None:
-    if transaction.gasLimit > config.MAX_GAS_LIMIT:
-        raise errors.GasLimitTooLarge(transaction.gasLimit, config.MAX_GAS_LIMIT)
 
 
 def sign_message_with_bls_key(message, seed):

--- a/erdpy/wallet/signing.py
+++ b/erdpy/wallet/signing.py
@@ -4,11 +4,10 @@ from typing import Any
 
 import nacl.encoding
 import nacl.signing
-from erdpy import config, dependencies, myprocess
+from erdpy import config, dependencies, myprocess, transactions
 from erdpy import errors
 from erdpy.errors import CannotSignMessageWithBLSKey
 from erdpy.interfaces import IAccount, ITransaction
-from erdpy.transactions import Transaction
 
 logger = logging.getLogger("wallet")
 
@@ -26,7 +25,7 @@ def sign_transaction(transaction: ITransaction, account: IAccount) -> str:
     return signature_hex
 
 
-def validate_transaction(transaction: Transaction) -> None:
+def validate_transaction(transaction: transactions.Transaction) -> None:
     if transaction.gasLimit > config.MAX_GAS_LIMIT:
         raise errors.GasLimitTooLarge(transaction.gasLimit, config.MAX_GAS_LIMIT)
 

--- a/erdpy/wallet/signing.py
+++ b/erdpy/wallet/signing.py
@@ -4,9 +4,11 @@ from typing import Any
 
 import nacl.encoding
 import nacl.signing
-from erdpy import dependencies, myprocess
+from erdpy import config, dependencies, myprocess
+from erdpy import errors
 from erdpy.errors import CannotSignMessageWithBLSKey
 from erdpy.interfaces import IAccount, ITransaction
+from erdpy.transactions import Transaction
 
 logger = logging.getLogger("wallet")
 
@@ -22,6 +24,11 @@ def sign_transaction(transaction: ITransaction, account: IAccount) -> str:
     assert isinstance(signature_hex, str)
 
     return signature_hex
+
+
+def validate_transaction(transaction: Transaction) -> None:
+    if transaction.gasLimit > config.MAX_GAS_LIMIT:
+        raise errors.GasLimitTooLarge(transaction.gasLimit, config.MAX_GAS_LIMIT)
 
 
 def sign_message_with_bls_key(message, seed):


### PR DESCRIPTION
Add a check when signing transactions so that the gas limit is below the maximum allowed, which is currently `600000000`.