### PR TITLE
Update template creation logic to handle "meta"

### DIFF
--- a/erdpy/projects/templates.py
+++ b/erdpy/projects/templates.py
@@ -255,7 +255,7 @@ class TemplateRust(Template):
 
     def _patch_source_code_meta(self):
         meta_main_path = path.join(self.directory, "meta", "src", "main.rs")
-        if not path.exists(abi_main_path):
+        if not path.exists(meta_main_path):
             return
 
         template_name = self.template_name.replace('-', '_')


### PR DESCRIPTION
Updated the template creation logic to also handle the new "meta" directory, that replaced the "abi" directory