### PR TITLE
Run all tests; Fix `query_latest_release_tag`

### DIFF
--- a/.github/workflows/erdpy.yml
+++ b/.github/workflows/erdpy.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         export PYTHONPATH=.
         python3 -m unittest discover -s erdpy/tests
-        pytest ./erdpy/tests/test_testnet.py -s
+        pytest .
     - name: Run CLI tests
       run: |
         cd ./erdpy/tests

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -258,14 +258,15 @@ def get_dependency_parent_directory(key: str) -> Path:
 
 def get_latest_semver_from_directory(directory: Path) -> str:
     subdirs = [subdir.name for subdir in directory.iterdir()]
-    versions = parse_strings_to_semver(subdirs)
-    if len(versions) == 0:
+    try:
+        return get_latest_semver(subdirs)
+    except IndexError:
         raise Exception(f'no versions found in {directory}')
 
-    if len(versions) == 1:
-        latest_version = versions[0]
-    else:
-        latest_version = sorted(versions).pop()
+
+def get_latest_semver(versions: List[str]) -> str:
+    semantic_versions = parse_strings_to_semver(versions)
+    latest_version = sorted(semantic_versions).pop()
     return 'v' + str(latest_version)
 
 

--- a/erdpy/tests/test_modules.py
+++ b/erdpy/tests/test_modules.py
@@ -1,5 +1,6 @@
 import semver
-from erdpy.dependencies.modules import StandaloneModule
+import pytest
+from erdpy.config import get_latest_semver
 
 
 def test_semver_parsing():
@@ -12,6 +13,12 @@ def test_semver_parsing():
 
 
 def test_semver_sorting():
-    folders = ['master', 'development', 'v1.2.3', 'v1.3.19', 'v0.1.1-beta.2']
-    latest = StandaloneModule.get_latest_semver_from_folder_list(folders)
+    versions = ['master', 'development', 'v1.2.3', 'v1.3.19', 'v0.1.1-beta.2']
+    latest = get_latest_semver(versions)
     assert latest == 'v1.3.19'
+
+
+def test_latest_semver_raises_for_empty_list():
+    versions = []
+    with pytest.raises(IndexError):
+        get_latest_semver(versions)

--- a/erdpy/utils.py
+++ b/erdpy/utils.py
@@ -239,7 +239,7 @@ def query_latest_release_tag(repo: str) -> str:
     Queries the Github API to retrieve the latest released tag of the specified
     repository. The repository must be of the form 'organisation/project'.
     """
-    url = f'https://api.github.com/repos/{repo}/releases/latest'
+    url = f'https://api.github.com/repos/{repo}/releases'
 
     github_api_token = erdpy.config.get_value('github_api_token')
     headers = dict()
@@ -249,8 +249,12 @@ def query_latest_release_tag(repo: str) -> str:
     response = requests.get(url, headers=headers)
     response.raise_for_status()
 
-    latest_release_tag = str(response.json()['tag_name'])
-    return latest_release_tag
+    release_tags = [str(release['tag_name']) for release in response.json()]
+    try:
+        latest_release_tag = erdpy.config.get_latest_semver(release_tags)
+        return latest_release_tag
+    except IndexError:
+        raise Exception(f"no releases in {repo}")
 
 
 # https://code.visualstudio.com/docs/python/debugging


### PR DESCRIPTION
- some tests which use `pytest` were not run at all - fix this by calling `pytest .` in the github action
- fix `query_latest_release_tag` because the github API `releases/latest` would get the most recent release (chronologically) and not semantically (eg. it would get `v1.3.0` instead of `v1.4.0` if the former would be more recent)
- refactor `get_latest_semver_from_directory` to extract common functionality into `config.get_latest_semver`
- fix broken test `test_semver_sorting` (now tests `config.get_latest_semver`)
- tested `query_latest_release_tag` changes locally:
```
>>> from erdpy import utils
>>> utils.query_latest_release_tag("ElrondNetwork/wasm-vm")
'v1.4.27'
```