### PR TITLE
Fix installation when `venv` has to be installed

### DIFF
--- a/.github/workflows/erdpy.yml
+++ b/.github/workflows/erdpy.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-18.04, ubuntu-latest, macos-latest]
         python-version: [3.8]
 
     steps:

--- a/erdpy-up.py
+++ b/erdpy-up.py
@@ -132,7 +132,7 @@ def require_venv():
     except ModuleNotFoundError:
         if operating_system == "linux":
             python_venv = f"python{sys.version_info.major}.{sys.version_info.minor}-venv"
-            raise InstallError(f'Packages [venv] or [ensurepip] not found. Please run "sudo apt-get install {python_venv}" and then run erdpy-up again.')
+            raise InstallError(f'Packages [venv] or [ensurepip] not found. Please run "sudo apt install {python_venv}" and then run erdpy-up again.')
         else:
             raise InstallError("Packages [venv] or [ensurepip] not found, please install them first. See https://docs.python.org/3/tutorial/venv.html.")
 

--- a/erdpy-up.py
+++ b/erdpy-up.py
@@ -132,7 +132,7 @@ def require_venv():
     except ModuleNotFoundError:
         if operating_system == "linux":
             python_venv = f"python{sys.version_info.major}.{sys.version_info.minor}-venv"
-            raise InstallError(f'Packages [venv] or [ensurepip] not found. Try installing them by running: "sudo apt-get install {python_venv}"')
+            raise InstallError(f'Packages [venv] or [ensurepip] not found. Please run "sudo apt-get install {python_venv}" and then run erdpy-up again.')
         else:
             raise InstallError("Packages [venv] or [ensurepip] not found, please install them first. See https://docs.python.org/3/tutorial/venv.html.")
 

--- a/erdpy-up.py
+++ b/erdpy-up.py
@@ -131,14 +131,8 @@ def require_venv():
         logger.info(f"Packages found: {ensurepip}, {venv}.")
     except ModuleNotFoundError:
         if operating_system == "linux":
-            logger.info("Package [venv] or [ensurepip] not found, will be installed.")
             python_venv = f"python{sys.version_info.major}.{sys.version_info.minor}-venv"
-            logger.info(f"Running [$ sudo apt-get install {python_venv}]:")
-            return_code = os.system(f"sudo apt-get install {python_venv}")
-            if return_code == 0:
-                logger.info(f"Done installing [{python_venv}].")
-            else:
-                raise InstallError("Packages [venv] or [ensurepip] not installed correctly.")
+            raise InstallError(f'Packages [venv] or [ensurepip] not found. Try installing them by running: "sudo apt-get install {python_venv}"')
         else:
             raise InstallError("Packages [venv] or [ensurepip] not found, please install them first. See https://docs.python.org/3/tutorial/venv.html.")
 

--- a/erdpy-up.py
+++ b/erdpy-up.py
@@ -11,8 +11,7 @@ from argparse import ArgumentParser
 logger = logging.getLogger("installer")
 
 MIN_REQUIRED_PYTHON_MAJOR_VERSION = 3
-MIN_REQUIRED_PYTHON_MINOR_VERSION = 6
-MIN_REQUIRED_PYTHON_MINOR_VERSION_MACOS = 8
+MIN_REQUIRED_PYTHON_MINOR_VERSION = 8
 
 elrondsdk_path = None
 exact_version = None
@@ -51,9 +50,7 @@ def main():
     logger.info("Checking Python version.")
     logger.info(f"Python version: {sys.version_info}")
     if python_major_version < MIN_REQUIRED_PYTHON_MAJOR_VERSION or (python_major_version >= MIN_REQUIRED_PYTHON_MAJOR_VERSION and python_minor_version < MIN_REQUIRED_PYTHON_MINOR_VERSION):
-        raise InstallError("You need Python 3.6 or later.")
-    if operating_system == "osx" and python_minor_version < MIN_REQUIRED_PYTHON_MINOR_VERSION_MACOS:
-        raise InstallError("On MacOS, you need Python 3.8 or later.")
+        raise InstallError(f"You need Python 3.8 or later.")
 
     logger.info("Checking operating system.")
     logger.info(f"Operating system: {operating_system}")

--- a/erdpy-up.py
+++ b/erdpy-up.py
@@ -7,11 +7,11 @@ import subprocess
 import sys
 import json
 from argparse import ArgumentParser
+from packaging import version
 
 logger = logging.getLogger("installer")
 
-MIN_REQUIRED_PYTHON_MAJOR_VERSION = 3
-MIN_REQUIRED_PYTHON_MINOR_VERSION = 8
+MIN_REQUIRED_PYTHON_VERSION = '3.8'
 
 elrondsdk_path = None
 exact_version = None
@@ -40,17 +40,17 @@ def main():
     logging.basicConfig(level=logging.DEBUG)
 
     operating_system = get_operating_system()
-    python_major_version = sys.version_info.major
-    python_minor_version = sys.version_info.minor
+    python_version = version.parse(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
 
     logger.info("Checking user.")
     if os.getuid() == 0:
         raise InstallError("You should not install erdpy as root.")
 
     logger.info("Checking Python version.")
-    logger.info(f"Python version: {sys.version_info}")
-    if python_major_version < MIN_REQUIRED_PYTHON_MAJOR_VERSION or (python_major_version >= MIN_REQUIRED_PYTHON_MAJOR_VERSION and python_minor_version < MIN_REQUIRED_PYTHON_MINOR_VERSION):
-        raise InstallError(f"You need Python 3.8 or later.")
+    logger.info(f"Python version: {python_version}")
+    minimum_required_python_version = version.parse(MIN_REQUIRED_PYTHON_VERSION)
+    if python_version < minimum_required_python_version:
+        raise InstallError(f"You need Python {minimum_required_python_version} or later.")
 
     logger.info("Checking operating system.")
     logger.info(f"Operating system: {operating_system}")
@@ -132,10 +132,11 @@ def require_venv():
     except ModuleNotFoundError:
         if operating_system == "linux":
             logger.info("Package [venv] or [ensurepip] not found, will be installed.")
-            logger.info("Running [$ sudo apt-get install python3.8-venv]:")
-            return_code = os.system("sudo apt-get install python3.8-venv")
+            python_venv = f"python{sys.version_info.major}.{sys.version_info.minor}-venv"
+            logger.info(f"Running [$ sudo apt-get install {python_venv}]:")
+            return_code = os.system(f"sudo apt-get install {python_venv}")
             if return_code == 0:
-                logger.info("Done installing [python3.8-venv].")
+                logger.info(f"Done installing [{python_venv}].")
             else:
                 raise InstallError("Packages [venv] or [ensurepip] not installed correctly.")
         else:

--- a/erdpy-up.py
+++ b/erdpy-up.py
@@ -135,10 +135,10 @@ def require_venv():
     except ModuleNotFoundError:
         if operating_system == "linux":
             logger.info("Package [venv] or [ensurepip] not found, will be installed.")
-            logger.info("Running [$ sudo apt-get install python3-venv]:")
-            return_code = os.system("sudo apt-get install python3-venv")
+            logger.info("Running [$ sudo apt-get install python3.8-venv]:")
+            return_code = os.system("sudo apt-get install python3.8-venv")
             if return_code == 0:
-                logger.info("Done installing [python3-venv].")
+                logger.info("Done installing [python3.8-venv].")
             else:
                 raise InstallError("Packages [venv] or [ensurepip] not installed correctly.")
         else:


### PR DESCRIPTION
Fix installation via `erdpy-up` for ubuntu 18.04 when `python3.8-venv` is not already installed.