### PR TITLE
Fix build (test) issues on Github Actions by setting erdpy's "github_api_token"

### DIFF
--- a/.github/workflows/erdpy.yml
+++ b/.github/workflows/erdpy.yml
@@ -32,8 +32,9 @@ jobs:
         pip3 install pytest
     - name: Set github_api_token
       run: |
-        mkdir ~/elrondsdk && touch ~/elrondsdk/erdpy.json
+        mkdir ~/elrondsdk
         export PYTHONPATH=.
+        python3 -m erdpy.cli config new test
         python3 -m erdpy.cli config set github_api_token ${{ secrets.GITHUB_TOKEN }}
     - name: Run unit tests
       run: |

--- a/.github/workflows/erdpy.yml
+++ b/.github/workflows/erdpy.yml
@@ -32,6 +32,7 @@ jobs:
         pip3 install pytest
     - name: Set github_api_token
       run: |
+        mkdir ~/elrondsdk && touch ~/elrondsdk/erdpy.json
         export PYTHONPATH=.
         python3 -m erdpy.cli config set github_api_token ${{ secrets.GITHUB_TOKEN }}
     - name: Run unit tests

--- a/.github/workflows/erdpy.yml
+++ b/.github/workflows/erdpy.yml
@@ -30,6 +30,10 @@ jobs:
         python3 -m pip install --upgrade pip
         pip3 install -r requirements.txt
         pip3 install pytest
+    - name: Set github_api_token
+      run: |
+        export PYTHONPATH=.
+        python3 -m erdpy.cli config set github_api_token ${{ secrets.GITHUB_TOKEN }}
     - name: Run unit tests
       run: |
         export PYTHONPATH=.

--- a/.github/workflows/erdpy.yml
+++ b/.github/workflows/erdpy.yml
@@ -8,6 +8,25 @@ on:
     branches: [ main, development ]
   workflow_dispatch:
 
+# At the start of each workflow run, GitHub automatically creates a unique GITHUB_TOKEN secret (we will pass it below to erdpy config).
+# The token's permissions are limited to the repository that contains your workflow.
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build-erdpy:
     name: Build and Test erdpy for ${{ matrix.os }}, python ${{ matrix.python-version }}

--- a/erdpy/cli_config.py
+++ b/erdpy/cli_config.py
@@ -51,11 +51,17 @@ def _add_name_arg(sub: Any):
 
 def dump(args: Any):
     if args.defaults:
-        data = config.get_defaults()
+        _dump_defaults()
     else:
-        data = config.get_active()
+        _dump_active()
 
-    utils.dump_out_json(data, sys.stdout)
+
+def _dump_defaults():
+    utils.dump_out_json(config.get_defaults(), sys.stdout)
+
+
+def _dump_active():
+    utils.dump_out_json(config.get_active(), sys.stdout)
 
 
 def get_value(args: Any):
@@ -73,12 +79,12 @@ def delete_value(args: Any):
 
 def new_config(args: Any):
     config.create_new_config(name=args.name, template=args.template)
-    dump(None)
+    _dump_active()
 
 
 def switch_config(args: Any):
     config.set_active(args.name)
-    dump(None)
+    _dump_active()
 
 
 def list_configs(args: Any):

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -84,12 +84,13 @@ def delete_value(name: str):
     write_file(data)
 
 
-def get_active():
+def get_active() -> Dict[str, Any]:
     data = read_file()
     configs = data.get("configurations", {})
     active_config = data.get("active", "default")
-
-    return configs.get(active_config, {})
+    empty_config: Dict[str, Any] = dict()
+    
+    return configs.get(active_config, empty_config)
 
 
 def set_active(name: str):

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -87,7 +87,7 @@ def delete_value(name: str):
 def get_active() -> Dict[str, Any]:
     data = read_file()
     configs = data.get("configurations", {})
-    active_config = data.get("active", "default")
+    active_config: Dict[str, Any] = data.get("active", "default")
     empty_config: Dict[str, Any] = dict()
     
     return configs.get(active_config, empty_config)

--- a/erdpy/config.py
+++ b/erdpy/config.py
@@ -87,10 +87,11 @@ def delete_value(name: str):
 def get_active() -> Dict[str, Any]:
     data = read_file()
     configs = data.get("configurations", {})
-    active_config: Dict[str, Any] = data.get("active", "default")
+    active_config_name: str = data.get("active", "default")
     empty_config: Dict[str, Any] = dict()
-    
-    return configs.get(active_config, empty_config)
+    result: Dict[str, Any] = configs.get(active_config_name, empty_config)
+
+    return result;
 
 
 def set_active(name: str):


### PR DESCRIPTION
New step in erdpy.yml: set `github_api_token`.

Using the token is safe because:
 - At the start of each workflow run, GitHub automatically creates a unique `GITHUB_TOKEN` secret.
 - The token's permissions are limited to the repository that contains your workflow.
 - The permissions are set to `restricted` at the repository level. Additionally, the workflow explicitly sets all possible (known as of February 2022) permissions to `none`. 

References:
 - https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
 - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions