### PR TITLE
Extend argument input types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 *$py.class
 .pytest_cache/
 erdpy/tests/testdata-out
+.idea
 
 # mypy
 .mypy_cache/

--- a/erdpy/CLI.md
+++ b/erdpy/CLI.md
@@ -187,7 +187,7 @@ optional arguments:
   --options OPTIONS                            the transaction options (default: 0)
   --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as [number, bech32-address, ascii
                                                string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
-                                               TOK-a1c2ef true erd1[..]
+                                               str:TOK-a1c2ef true erd1[..]
   --wait-result                                signal to wait for the transaction result - only valid if --send is set
   --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
                                                set
@@ -231,7 +231,7 @@ optional arguments:
   --function FUNCTION                          the function to call
   --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as [number, bech32-address, ascii
                                                string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
-                                               TOK-a1c2ef true erd1[..]
+                                               str:TOK-a1c2ef true erd1[..]
   --wait-result                                signal to wait for the transaction result - only valid if --send is set
   --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
                                                set
@@ -281,7 +281,7 @@ optional arguments:
   --options OPTIONS                            the transaction options (default: 0)
   --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as [number, bech32-address, ascii
                                                string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
-                                               TOK-a1c2ef true erd1[..]
+                                               str:TOK-a1c2ef true erd1[..]
   --wait-result                                signal to wait for the transaction result - only valid if --send is set
   --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
                                                set
@@ -307,7 +307,7 @@ optional arguments:
   --function FUNCTION                    the function to call
   --arguments ARGUMENTS [ARGUMENTS ...]  arguments for the contract transaction, as [number, bech32-address, ascii
                                          string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
-                                         TOK-a1c2ef true erd1[..]
+                                         str:TOK-a1c2ef true erd1[..]
 
 ```
 ## Group **Transactions**

--- a/erdpy/CLI.md
+++ b/erdpy/CLI.md
@@ -185,8 +185,9 @@ optional arguments:
   --chain CHAIN                                the chain identifier (default: T)
   --version VERSION                            the transaction version (default: 1)
   --options OPTIONS                            the transaction options (default: 0)
-  --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as numbers or hex-encoded. E.g.
-                                               --arguments 42 0x64 1000 0xabba
+  --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as [number, bech32-address, ascii
+                                               string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
+                                               TOK-a1c2ef true erd1[..]
   --wait-result                                signal to wait for the transaction result - only valid if --send is set
   --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
                                                set
@@ -228,8 +229,9 @@ optional arguments:
   --version VERSION                            the transaction version (default: 1)
   --options OPTIONS                            the transaction options (default: 0)
   --function FUNCTION                          the function to call
-  --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as numbers or hex-encoded. E.g.
-                                               --arguments 42 0x64 1000 0xabba
+  --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as [number, bech32-address, ascii
+                                               string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
+                                               TOK-a1c2ef true erd1[..]
   --wait-result                                signal to wait for the transaction result - only valid if --send is set
   --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
                                                set
@@ -277,8 +279,9 @@ optional arguments:
   --chain CHAIN                                the chain identifier (default: T)
   --version VERSION                            the transaction version (default: 1)
   --options OPTIONS                            the transaction options (default: 0)
-  --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as numbers or hex-encoded. E.g.
-                                               --arguments 42 0x64 1000 0xabba
+  --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as [number, bech32-address, ascii
+                                               string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
+                                               TOK-a1c2ef true erd1[..]
   --wait-result                                signal to wait for the transaction result - only valid if --send is set
   --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
                                                set
@@ -302,8 +305,9 @@ optional arguments:
   -h, --help                             show this help message and exit
   --proxy PROXY                          🔗 the URL of the proxy (default: https://testnet-gateway.elrond.com)
   --function FUNCTION                    the function to call
-  --arguments ARGUMENTS [ARGUMENTS ...]  arguments for the contract transaction, as numbers or hex-encoded. E.g.
-                                         --arguments 42 0x64 1000 0xabba
+  --arguments ARGUMENTS [ARGUMENTS ...]  arguments for the contract transaction, as [number, bech32-address, ascii
+                                         string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
+                                         TOK-a1c2ef true erd1[..]
 
 ```
 ## Group **Transactions**

--- a/erdpy/cli_contracts.py
+++ b/erdpy/cli_contracts.py
@@ -143,7 +143,7 @@ def _add_function_arg(sub: Any):
 def _add_arguments_arg(sub: Any):
     sub.add_argument("--arguments", nargs='+',
                      help="arguments for the contract transaction, as [number, bech32-address, ascii string, "
-                          "boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba TOK-a1c2ef true erd1[..]")
+                          "boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba str:TOK-a1c2ef true erd1[..]")
 
 
 def _add_metadata_arg(sub: Any):

--- a/erdpy/cli_contracts.py
+++ b/erdpy/cli_contracts.py
@@ -142,7 +142,8 @@ def _add_function_arg(sub: Any):
 
 def _add_arguments_arg(sub: Any):
     sub.add_argument("--arguments", nargs='+',
-                     help="arguments for the contract transaction, as numbers or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba")
+                     help="arguments for the contract transaction, as [number, bech32-address, ascii string, "
+                          "boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba TOK-a1c2ef true erd1[..]")
 
 
 def _add_metadata_arg(sub: Any):
@@ -252,7 +253,7 @@ def _prepare_contract(args: Any) -> SmartContract:
         bytecode = project.get_bytecode()
 
     metadata = CodeMetadata(upgradeable=args.metadata_upgradeable, readable=args.metadata_readable,
-        payable=args.metadata_payable, payable_by_sc=args.metadata_payable_by_sc)
+                            payable=args.metadata_payable, payable_by_sc=args.metadata_payable_by_sc)
     contract = SmartContract(bytecode=bytecode, metadata=metadata)
     return contract
 

--- a/erdpy/contracts.py
+++ b/erdpy/contracts.py
@@ -32,8 +32,7 @@ class SmartContract:
         self.bytecode = bytecode
         self.metadata = metadata or CodeMetadata()
 
-    def deploy(self, owner: Account, arguments: List[Any], gas_price: int, gas_limit: int, value: int, chain: str,
-               version: int) -> Transaction:
+    def deploy(self, owner: Account, arguments: List[Any], gas_price: int, gas_limit: int, value: int, chain: str, version: int) -> Transaction:
         self.owner = owner
         self.compute_address()
 
@@ -75,8 +74,7 @@ class SmartContract:
         address = bytes([0] * 8) + bytes([5, 0]) + address[10:30] + owner_bytes[30:]
         self.address = Address(address)
 
-    def execute(self, caller: Account, function: str, arguments: List[str], gas_price: int, gas_limit: int, value: int,
-                chain: str, version: int) -> Transaction:
+    def execute(self, caller: Account, function: str, arguments: List[str], gas_price: int, gas_limit: int, value: int, chain: str, version: int) -> Transaction:
         self.caller = caller
 
         arguments = arguments or []
@@ -106,8 +104,7 @@ class SmartContract:
 
         return tx_data
 
-    def upgrade(self, owner: Account, arguments: List[Any], gas_price: int, gas_limit: int, value: int, chain: str,
-                version: int) -> Transaction:
+    def upgrade(self, owner: Account, arguments: List[Any], gas_price: int, gas_limit: int, value: int, chain: str, version: int) -> Transaction:
         self.owner = owner
 
         arguments = arguments or []
@@ -138,19 +135,18 @@ class SmartContract:
         return tx_data
 
     def query(
-            self,
-            proxy: IElrondProxy,
-            function: str,
-            arguments: List[Any],
-            value: int = 0,
-            caller: Optional[Address] = None
+        self,
+        proxy: IElrondProxy,
+        function: str,
+        arguments: List[Any],
+        value: int = 0,
+        caller: Optional[Address] = None
     ) -> List[Any]:
         response_data = self.query_detailed(proxy, function, arguments, value, caller)
         return_data = response_data.get("returnData", []) or response_data.get("ReturnData", [])
         return [self._interpret_return_data(data) for data in return_data]
 
-    def query_detailed(self, proxy: IElrondProxy, function: str, arguments: List[Any], value: int = 0,
-                       caller: Optional[Address] = None) -> Any:
+    def query_detailed(self, proxy: IElrondProxy, function: str, arguments: List[Any], value: int = 0, caller: Optional[Address] = None) -> Any:
         arguments = arguments or []
         prepared_arguments = [_prepare_argument(argument) for argument in arguments]
 
@@ -245,8 +241,7 @@ def sum_flag_values(flag_value_pairs: List[Tuple[int, bool]]) -> int:
 
 
 class CodeMetadata:
-    def __init__(self, upgradeable: bool = True, readable: bool = True, payable: bool = False,
-                 payable_by_sc: bool = False):
+    def __init__(self, upgradeable: bool = True, readable: bool = True, payable: bool = False, payable_by_sc: bool = False):
         self.upgradeable = upgradeable
         self.readable = readable
         self.payable = payable

--- a/erdpy/contracts.py
+++ b/erdpy/contracts.py
@@ -12,7 +12,10 @@ from erdpy.utils import Object
 
 logger = logging.getLogger("contracts")
 
-HEX_PREFIX = "0X"
+HEX_PREFIX = "0x"
+ERD_BECH32_PREFIX = "erd"
+FALSE_STR_LOWER = "false"
+TRUE_STR_LOWER = "true"
 
 
 class QueryResult(Object):
@@ -177,16 +180,33 @@ class SmartContract:
 
 
 def _prepare_argument(argument: Any):
-    as_string = str(argument).upper()
+    as_str = str(argument)
+    as_hex = _to_hex(as_str)
+    return as_hex
 
-    if as_string.startswith(HEX_PREFIX):
-        return _prepare_hexadecimal(as_string)
 
-    return _prepare_decimal(as_string)
+def _to_hex(arg: str):
+    if arg.startswith(HEX_PREFIX):
+        return _prepare_hexadecimal(arg)
+
+    if arg.isnumeric():
+        return _prepare_decimal(arg)
+    elif arg.startswith(ERD_BECH32_PREFIX):
+        addr = Address(arg)
+        return _prepare_hexadecimal(f"{HEX_PREFIX}{addr.hex()}")
+    elif arg.lower() == FALSE_STR_LOWER or arg.lower() == TRUE_STR_LOWER:
+        as_str = f"{HEX_PREFIX}01" if arg.lower() == TRUE_STR_LOWER else f"{HEX_PREFIX}00"
+        return _prepare_hexadecimal(as_str)
+    elif arg.isascii():
+        as_hex = f"{HEX_PREFIX}{arg.encode('ascii').hex()}"
+        return _prepare_hexadecimal(as_hex)
+    else:
+        raise Exception(f"could not convert {arg} to hex")
 
 
 def _prepare_hexadecimal(argument: str) -> str:
     argument = argument[len(HEX_PREFIX):]
+    argument = argument.upper()
     argument = ensure_even_length(argument)
     try:
         _ = int(argument, 16)
@@ -202,7 +222,7 @@ def _prepare_decimal(argument: str) -> str:
     as_number = int(argument)
     as_hexstring = hex(as_number)[len(HEX_PREFIX):]
     as_hexstring = ensure_even_length(as_hexstring)
-    return as_hexstring
+    return as_hexstring.upper()
 
 
 def ensure_even_length(string: str) -> str:

--- a/erdpy/tests/test_contracts.py
+++ b/erdpy/tests/test_contracts.py
@@ -34,9 +34,23 @@ def test_prepare_argument():
     assert _prepare_argument('5') == '05'
     assert _prepare_argument('0x05f') == '005F'
     assert _prepare_argument('0xaaa') == '0AAA'
+    assert _prepare_argument('aaa') == '616161'
+
+    assert _prepare_argument(155) == '9B'
+    assert _prepare_argument('155') == '9B'
+
+    assert \
+        _prepare_argument('erd1qr9av6ar4ymr05xj93jzdxyezdrp6r4hz6u0scz4dtzvv7kmlldse7zktc') == \
+        '00CBD66BA3A93637D0D22C6426989913461D0EB716B8F860556AC4C67ADBFFDB'
+
+    assert _prepare_argument('TOK-123456') == '544F4B2D313233343536'
+    assert _prepare_argument('TOK-a1c2ef') == '544F4B2D613163326566'
+    assert _prepare_argument('TokenName') == '546F6B656E4E616D65'
+
+    assert _prepare_argument(True) == "01"
+    assert _prepare_argument(False) == "00"
+    assert _prepare_argument("TrUe") == "01"
+    assert _prepare_argument("fAlSe") == "00"
 
     with pytest.raises(errors.UnknownArgumentFormat):
         _ = _prepare_argument('0x05fq')
-
-    with pytest.raises(errors.UnknownArgumentFormat):
-        _ = _prepare_argument('aaa')

--- a/erdpy/tests/test_contracts.py
+++ b/erdpy/tests/test_contracts.py
@@ -34,6 +34,7 @@ def test_prepare_argument():
     assert _prepare_argument('5') == '05'
     assert _prepare_argument('0x05f') == '005F'
     assert _prepare_argument('0xaaa') == '0AAA'
+    assert _prepare_argument('str:a') == '61'
     assert _prepare_argument('str:aaa') == '616161'
 
     assert _prepare_argument(155) == '9B'

--- a/erdpy/tests/test_contracts.py
+++ b/erdpy/tests/test_contracts.py
@@ -34,7 +34,7 @@ def test_prepare_argument():
     assert _prepare_argument('5') == '05'
     assert _prepare_argument('0x05f') == '005F'
     assert _prepare_argument('0xaaa') == '0AAA'
-    assert _prepare_argument('aaa') == '616161'
+    assert _prepare_argument('str:aaa') == '616161'
 
     assert _prepare_argument(155) == '9B'
     assert _prepare_argument('155') == '9B'
@@ -43,9 +43,10 @@ def test_prepare_argument():
         _prepare_argument('erd1qr9av6ar4ymr05xj93jzdxyezdrp6r4hz6u0scz4dtzvv7kmlldse7zktc') == \
         '00CBD66BA3A93637D0D22C6426989913461D0EB716B8F860556AC4C67ADBFFDB'
 
-    assert _prepare_argument('TOK-123456') == '544F4B2D313233343536'
-    assert _prepare_argument('TOK-a1c2ef') == '544F4B2D613163326566'
-    assert _prepare_argument('TokenName') == '546F6B656E4E616D65'
+    assert _prepare_argument('str:TOK-123456') == '544F4B2D313233343536'
+    assert _prepare_argument('str:TOK-a1c2ef') == '544F4B2D613163326566'
+    assert _prepare_argument('str:TokenName') == '546F6B656E4E616D65'
+    assert _prepare_argument('str:/#%placeholder&*') == '2F2325706C616365686F6C646572262A'
 
     assert _prepare_argument(True) == "01"
     assert _prepare_argument(False) == "00"


### PR DESCRIPTION
Extend the functionality of cli:contract --argument field to support more types. Added the following options:
- bech32 address (`erd1qqq...`)
- boolean values
- ascii, such as token identifiers or names can be passed directly

Hex values are treated as before, so are numeric ones