### PR TITLE
Fix activation flag check, fix flag name

### DIFF
--- a/erdpy/CHANGELOG.md
+++ b/erdpy/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
- - TBD
+ - [Fix activation flag check, fix flag name](https://github.com/ElrondNetwork/elrond-sdk-erdpy/pull/123)
 
 ## [1.2.2]
- - [ Add (update) examples of using erdpy in Python scripts. Refactoring.](https://github.com/ElrondNetwork/elrond-sdk-erdpy/pull/120)
+ - [Add (update) examples of using erdpy in Python scripts. Refactoring.](https://github.com/ElrondNetwork/elrond-sdk-erdpy/pull/120)
  - [Allow "str:" and "0x" as contract arguments, as well](https://github.com/ElrondNetwork/elrond-sdk-erdpy/pull/121)
 
 ## [1.2.1] - 07.03.2022

--- a/erdpy/projects/eei_activation.py
+++ b/erdpy/projects/eei_activation.py
@@ -24,7 +24,7 @@ class ActivationEpochsInfo(DiskCache):
         current_epoch = self.get_and_cache_item(current_epoch_key, self._fetch_current_epoch)
         enable_epochs = self.get_and_cache_item(enable_epochs_key, self._fetch_enable_epochs)
         enable_epoch = enable_epochs.get(flag_name, sys.maxsize)
-        return enable_epoch >= current_epoch
+        return current_epoch >= enable_epoch
 
     def _fetch_current_epoch(self):
         logger.info(f"fetch_current_epoch: {self.proxy_url}")

--- a/erdpy/projects/eei_registry.py
+++ b/erdpy/projects/eei_registry.py
@@ -8,10 +8,10 @@ class EEIRegistry:
     def __init__(self, activation_info: ActivationEpochsInfo) -> None:
         self.activation_info = activation_info
         
-        useDifferentGasCostForReadingCachedStorageEpoch = FeatureFlag("UseDifferentGasCostForReadingCachedStorageEpoch")
+        storageAPICostOptimizationEnableEpoch = FeatureFlag("StorageAPICostOptimizationEnableEpoch")
 
         self.flags = [
-            useDifferentGasCostForReadingCachedStorageEpoch
+            storageAPICostOptimizationEnableEpoch
         ]
 
         self.functions: List[EEIFunction] = [
@@ -81,7 +81,7 @@ class EEIRegistry:
             EEIFunction("mBufferCopyByteSlice", None, []),
             EEIFunction("mBufferEq", None, []),
             EEIFunction("mBufferSetBytes", None, []),
-            EEIFunction("mBufferSetByteSlice", useDifferentGasCostForReadingCachedStorageEpoch, []),
+            EEIFunction("mBufferSetByteSlice", storageAPICostOptimizationEnableEpoch, []),
             EEIFunction("mBufferAppend", None, []),
             EEIFunction("mBufferAppendBytes", None, []),
             EEIFunction("mBufferToBigIntUnsigned", None, []),
@@ -90,7 +90,7 @@ class EEIRegistry:
             EEIFunction("mBufferFromBigIntSigned", None, []),
             EEIFunction("mBufferStorageStore", None, []),
             EEIFunction("mBufferStorageLoad", None, []),
-            EEIFunction("mBufferStorageLoadFromAddress", useDifferentGasCostForReadingCachedStorageEpoch, []),
+            EEIFunction("mBufferStorageLoadFromAddress", storageAPICostOptimizationEnableEpoch, []),
             EEIFunction("mBufferGetArgument", None, []),
             EEIFunction("mBufferFinish", None, []),
             EEIFunction("mBufferSetRandom", None, []),
@@ -140,8 +140,8 @@ class EEIRegistry:
             EEIFunction("getESDTNFTAttributeLength", None, []),
             EEIFunction("getESDTNFTURILength", None, []),
             EEIFunction("getESDTTokenData", None, []),
-            EEIFunction("getESDTLocalRoles", useDifferentGasCostForReadingCachedStorageEpoch, []),
-            EEIFunction("validateTokenIdentifier", useDifferentGasCostForReadingCachedStorageEpoch, []),
+            EEIFunction("getESDTLocalRoles", storageAPICostOptimizationEnableEpoch, []),
+            EEIFunction("validateTokenIdentifier", storageAPICostOptimizationEnableEpoch, []),
             EEIFunction("executeOnDestContext", None, []),
             EEIFunction("executeOnDestContextByCaller", None, []),
             EEIFunction("executeOnSameContext", None, []),
@@ -154,8 +154,8 @@ class EEIRegistry:
             EEIFunction("getNumReturnData", None, []),
             EEIFunction("getReturnDataSize", None, []),
             EEIFunction("getReturnData", None, []),
-            EEIFunction("cleanReturnData", useDifferentGasCostForReadingCachedStorageEpoch, []),
-            EEIFunction("deleteFromReturnData", useDifferentGasCostForReadingCachedStorageEpoch, []),
+            EEIFunction("cleanReturnData", storageAPICostOptimizationEnableEpoch, []),
+            EEIFunction("deleteFromReturnData", storageAPICostOptimizationEnableEpoch, []),
             EEIFunction("setStorageLock", None, []),
             EEIFunction("getStorageLock", None, []),
             EEIFunction("isStorageLocked", None, []),
@@ -201,9 +201,9 @@ class EEIRegistry:
 
             # crypto
             EEIFunction("sha256", None, []),
-            EEIFunction("managedSha256", useDifferentGasCostForReadingCachedStorageEpoch, []),
+            EEIFunction("managedSha256", storageAPICostOptimizationEnableEpoch, []),
             EEIFunction("keccak256", None, []),
-            EEIFunction("managedKeccak256", useDifferentGasCostForReadingCachedStorageEpoch, []),
+            EEIFunction("managedKeccak256", storageAPICostOptimizationEnableEpoch, []),
             EEIFunction("ripemd160", None, []),
             EEIFunction("verifyBLS", None, []),
             EEIFunction("verifyEd25519", None, []),


### PR DESCRIPTION
The return statement of `ActivationEpochsInfo.is_flag_active()` was incorrect.

Furthermore, an activation flag was incorrectly named. See: 
 - https://github.com/ElrondNetwork/elrond-go/blob/master/cmd/node/config/enableEpochs.toml
 - `checkBackwardCompatibility()` in https://github.com/ElrondNetwork/wasm-vm/blob/master/arwen/contexts/runtime.go