### PR TITLE
Fix reference to libwasmer (referenced by mandos-test)

### DIFF
--- a/erdpy/dependencies/modules.py
+++ b/erdpy/dependencies/modules.py
@@ -159,17 +159,17 @@ class VMToolsModule(StandaloneModule):
         self.make_binary_symlink_in_parent_folder(tag, 'test', 'mandos-test')
         self.copy_libwasmer_in_parent_directory(tag)
 
-    def build_binary(self, tag, binary_name):
+    def build_binary(self, tag: str, binary_name: str):
         source_folder = self.binary_source_folder(tag, binary_name)
         golang = dependencies.get_module_by_key("golang")
         golang_env = golang.get_env()
         myprocess.run_process(['go', 'build'], cwd=source_folder, env=golang_env)
 
-    def binary_source_folder(self, tag, binary_name):
+    def binary_source_folder(self, tag: str, binary_name: str):
         directory = self.get_source_directory(tag)
         return directory / 'cmd' / binary_name
 
-    def make_binary_symlink_in_parent_folder(self, tag, binary_name, symlink_name):
+    def make_binary_symlink_in_parent_folder(self, tag: str, binary_name: str, symlink_name: str):
         source_folder = self.binary_source_folder(tag, binary_name)
         binary = source_folder / binary_name
 
@@ -179,16 +179,19 @@ class VMToolsModule(StandaloneModule):
         symlink.unlink(missing_ok=True)
         symlink.symlink_to(binary)
 
-    def copy_libwasmer_in_parent_directory(self, tag):
+    def copy_libwasmer_in_parent_directory(self, tag: str):
         libwasmer_directory = self.get_source_directory(tag) / 'wasmer'
+        cmd_test_directory = self.get_source_directory(tag) / 'cmd' / 'test'
         parent_directory = self.get_parent_directory()
         for f in libwasmer_directory.iterdir():
             if f.suffix in ['.dylib', '.so', '.dll']:
+                # Copy the dynamic library near the "mandos-test" symlink
                 shutil.copy(f, parent_directory)
+                # Though, also copy the dynamic library near the target executable (seems to be necessary on MacOS)
+                shutil.copy(f, cmd_test_directory)
 
-    def get_env(self):
-        return {
-        }
+    def get_env(self) -> Dict[str, str]:
+        return dict()
 
 
 class GolangModule(StandaloneModule):

--- a/erdpy/tests/test_cli_contracts.sh
+++ b/erdpy/tests/test_cli_contracts.sh
@@ -3,10 +3,12 @@
 source "./shared.sh"
 
 testTrivialCommands() {
+    echo "testTrivialCommands"
     ${ERDPY} contract templates
 }
 
 testCreateContracts() {
+    echo "testCreateContracts"
     ${ERDPY} contract new --template ultimate-answer --directory ${SANDBOX} myanswer-c || return 1
     ${ERDPY} contract new --template simple-counter --directory ${SANDBOX} mycounter-c || return 1
     ${ERDPY} contract new --template erc20-c --directory ${SANDBOX} myerc20-c || return 1
@@ -20,6 +22,7 @@ testCreateContracts() {
 }
 
 testBuildContracts() {
+    echo "testBuildContracts"
     ${ERDPY} contract build ${SANDBOX}/myanswer-c || return 1
     assertFileExists ${SANDBOX}/myanswer-c/output/answer.wasm || return 1
 
@@ -55,6 +58,7 @@ testBuildContracts() {
 }
 
 testRunMandos() {
+    echo "testRunMandos"
     ${ERDPY} --verbose contract test --directory="mandos" ${SANDBOX}/myadder-rs || return 1
     ${ERDPY} --verbose contract test --directory="mandos" ${SANDBOX}/mybubbles-rs || return 1
     ${ERDPY} --verbose contract test --directory="mandos" ${SANDBOX}/mylottery-rs || return 1
@@ -62,6 +66,7 @@ testRunMandos() {
 }
 
 testWasmName() {
+    echo "testWasmName"
     ${ERDPY} contract clean ${SANDBOX}/myanswer-c || return 1
     assertFileDoesNotExist ${SANDBOX}/myanswer-c/output/answer-2.wasm || return 1
     ${ERDPY} contract build ${SANDBOX}/myanswer-c --wasm-name answer-2 || return 1
@@ -75,6 +80,7 @@ testWasmName() {
 }
 
 testCleanContracts() {
+    echo "testCleanContracts"
     assertFileExists ${SANDBOX}/myanswer-c/output/answer.wasm || return 1
     ${ERDPY} contract clean ${SANDBOX}/myanswer-c || return 1
     assertFileDoesNotExist ${SANDBOX}/myanswer-c/output/answer.wasm || return 1


### PR DESCRIPTION
When installing `vmtools`, copy the dynamic library (libwasmer) near the target executable, as well (seems to be necessary on MacOS).

Fix becomes effective upon running:

```
erdpy deps install vmtools --overwrite
```