### PR TITLE
Prepare integration with erdjs-snippets (from templates)

### DIFF
--- a/erdpy/CHANGELOG.md
+++ b/erdpy/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
- - TBD
+ - [Prepare integration with erdjs-snippets (from templates)](https://github.com/ElrondNetwork/elrond-sdk-erdpy/pull/126)
 
 ## [1.2.3]
  - [Fix activation flag check, fix flag name](https://github.com/ElrondNetwork/elrond-sdk-erdpy/pull/123)

--- a/erdpy/accounts_repository.py
+++ b/erdpy/accounts_repository.py
@@ -20,7 +20,7 @@ class AccountsRepository:
         """
         Creates an AccountsRepository using a folder containing *.pem files.
         """
-        files = [Path(file) for file in utils.list_files(folder, suffix=".pem")]
+        files = utils.list_files(folder, suffix=".pem")
         return cls.create_from_files(files)
 
     @classmethod

--- a/erdpy/errors.py
+++ b/erdpy/errors.py
@@ -1,4 +1,5 @@
 
+from pathlib import Path
 from typing import Any, Union
 
 
@@ -24,6 +25,11 @@ class ProgrammingError(KnownError):
 class TemplateMissingError(KnownError):
     def __init__(self, template: str):
         super().__init__(f"Template missing: {template}")
+
+
+class BadTemplateError(KnownError):
+    def __init__(self, directory: Path):
+        super().__init__(f"Bad template: {directory}")
 
 
 class DownloadError(KnownError):

--- a/erdpy/projects/project_rust.py
+++ b/erdpy/projects/project_rust.py
@@ -261,7 +261,7 @@ class CargoFile:
         dev_dependencies = cast(Dict[str, Any], self.data['dev-dependencies'])
         return dev_dependencies
 
-    def get_dependency(self, name) -> Dict[str, Any]:
+    def get_dependency(self, name: str) -> Dict[str, Any]:
         dependencies = self.get_dependencies()
         dependency = cast(Dict[str, Any], dependencies.get(name))
         if dependency is None:

--- a/erdpy/projects/templates.py
+++ b/erdpy/projects/templates.py
@@ -14,6 +14,7 @@ from erdpy.projects.templates_repository import TemplatesRepository
 from erdpy.testnet import wallets
 
 logger = logging.getLogger("projects.templates")
+ERDJS_SNIPPETS_FOLDER_NAME = "erdjs-snippets"
 
 
 def list_project_templates():
@@ -82,11 +83,15 @@ def _copy_template(template: str, destination_path: Path, project_name: str):
 
 
 def _copy_erdjs_snippets(template: str,  templates_payload_folder: Path, destination_path: Path, project_name: str):
-    source_erdjs_snippets_folder = templates_payload_folder / "erdjs-snippets"
+    source_erdjs_snippets_folder = templates_payload_folder / ERDJS_SNIPPETS_FOLDER_NAME
     source_erdjs_snippets_subfolder = source_erdjs_snippets_folder / template
-    destination_erdjs_snippets_folder = destination_path.parent / "erdjs-snippets"
+    destination_erdjs_snippets_folder = destination_path.parent / ERDJS_SNIPPETS_FOLDER_NAME
+    no_snippets = not source_erdjs_snippets_subfolder.is_dir()
 
-    if not source_erdjs_snippets_subfolder.is_dir():
+    logger.info(f"_copy_erdjs_snippets, source_erdjs_snippets_subfolder: {source_erdjs_snippets_subfolder}")
+    logger.info(f"_copy_erdjs_snippets, destination_erdjs_snippets_folder: {destination_erdjs_snippets_folder}")
+
+    if no_snippets:
         logger.info(f"_copy_erdjs_snippets: no snippets in template {template}")
         return
 
@@ -94,16 +99,16 @@ def _copy_erdjs_snippets(template: str,  templates_payload_folder: Path, destina
 
     # Copy snippets to destination
     # First, copy the subfolder associated with the template
-    logger.info(f"_copy_erdjs_snippets, source_erdjs_snippets_subfolder: {source_erdjs_snippets_subfolder}")
-    logger.info(f"_copy_erdjs_snippets, destination_erdjs_snippets_folder: {destination_erdjs_snippets_folder}")
     shutil.copytree(source_erdjs_snippets_subfolder, destination_erdjs_snippets_folder / project_name)
 
-    # After that, copy the remaining files from the source folder (not recursively)
+    # After that, copy the remaining files from the source folder - not recursively (on purpose).
     for file in os.listdir(source_erdjs_snippets_folder):
         source_file = source_erdjs_snippets_folder / file
         destination_file = destination_erdjs_snippets_folder / file
-        if source_file.is_file() and not destination_file.exists():
-            logger.info(f"_copy_erdjs_snippets, source file: {source_file}")
+        should_copy = source_file.is_file() and not destination_file.exists()
+
+        if should_copy:
+            logger.info(f"_copy_erdjs_snippets, file: {file}")
             shutil.copy(source_file, destination_file)
 
 

--- a/erdpy/projects/templates.py
+++ b/erdpy/projects/templates.py
@@ -3,34 +3,35 @@ import logging
 import os
 from os import path
 from pathlib import Path
-import pathlib
-from typing import Any, Dict, List, Tuple, Union
+import shutil
+from typing import Any, List, Tuple
 
 from erdpy import errors, utils
 from erdpy.projects import shared
 from erdpy.projects.project_rust import CargoFile
 from erdpy.projects.templates_config import get_templates_repositories
+from erdpy.projects.templates_repository import TemplatesRepository
 from erdpy.testnet import wallets
 
 logger = logging.getLogger("projects.templates")
 
 
 def list_project_templates():
-    templates = []
+    summaries: List[TemplateSummary] = []
 
     for repository in get_templates_repositories():
         repository.download()
         for template in repository.get_templates():
-            templates.append(TemplateSummary(template, repository))
+            summaries.append(TemplateSummary(template, repository))
 
-    templates = sorted(templates, key=lambda item: item.name)
+    summaries = sorted(summaries, key=lambda item: item.name)
 
-    pretty_json = json.dumps([item.__dict__ for item in templates], indent=4)
+    pretty_json = json.dumps([item.__dict__ for item in summaries], indent=4)
     print(pretty_json)
 
 
 class TemplateSummary():
-    def __init__(self, name, repository):
+    def __init__(self, name: str, repository: TemplatesRepository):
         self.name = name
         self.github = repository.github
         self.language = repository.get_language(name)
@@ -52,7 +53,7 @@ def create_from_template(project_name: str, template_name: str, directory: Path)
         raise errors.BadDirectory(str(project_directory))
 
     _download_templates_repositories()
-    _copy_template(template_name, project_directory)
+    _copy_template(template_name, project_directory, project_name)
 
     template = _load_as_template(project_directory)
     template.apply(template_name, project_name)
@@ -69,13 +70,41 @@ def _download_templates_repositories():
         repo.download()
 
 
-def _copy_template(template: str, destination_path: Path):
+def _copy_template(template: str, destination_path: Path, project_name: str):
     for repo in get_templates_repositories():
         if repo.has_template(template):
-            repo.copy_template(template, destination_path)
+            source_path = repo.get_template_folder(template)
+            shutil.copytree(source_path, destination_path)
+            _copy_erdjs_snippets(template, repo.get_payload_folder(), destination_path, project_name)
             return
 
     raise errors.TemplateMissingError(template)
+
+
+def _copy_erdjs_snippets(template: str,  templates_payload_folder: Path, destination_path: Path, project_name: str):
+    source_erdjs_snippets_folder = templates_payload_folder / "erdjs-snippets"
+    source_erdjs_snippets_subfolder = source_erdjs_snippets_folder / template
+    destination_erdjs_snippets_folder = destination_path.parent / "erdjs-snippets"
+
+    if not source_erdjs_snippets_subfolder.is_dir():
+        logger.info(f"_copy_erdjs_snippets: no snippets in template {template}")
+        return
+
+    utils.ensure_folder(destination_erdjs_snippets_folder)
+
+    # Copy snippets to destination
+    # First, copy the subfolder associated with the template
+    logger.info(f"_copy_erdjs_snippets, source_erdjs_snippets_subfolder: {source_erdjs_snippets_subfolder}")
+    logger.info(f"_copy_erdjs_snippets, destination_erdjs_snippets_folder: {destination_erdjs_snippets_folder}")
+    shutil.copytree(source_erdjs_snippets_subfolder, destination_erdjs_snippets_folder / project_name)
+
+    # After that, copy the remaining files from the source folder (not recursively)
+    for file in os.listdir(source_erdjs_snippets_folder):
+        source_file = source_erdjs_snippets_folder / file
+        destination_file = destination_erdjs_snippets_folder / file
+        if source_file.is_file() and not destination_file.exists():
+            logger.info(f"_copy_erdjs_snippets, source file: {source_file}")
+            shutil.copy(source_file, destination_file)
 
 
 def _load_as_template(directory: Path):
@@ -83,13 +112,14 @@ def _load_as_template(directory: Path):
         return TemplateClang(directory)
     if shared.is_source_rust(directory):
         return TemplateRust(directory)
+    raise errors.BadTemplateError(directory)
 
 
 class Template:
     def __init__(self, directory: Path):
         self.directory = directory
 
-    def apply(self, template_name, project_name):
+    def apply(self, template_name: str, project_name: str):
         self.template_name = template_name
         self.project_name = project_name
         self._patch()
@@ -198,7 +228,7 @@ class TemplateRust(Template):
         if not test_dir_path.is_dir():
             return
 
-        test_paths = [e for e in utils.list_files(test_dir_path, suffix=".json")]
+        test_paths = utils.list_files(test_dir_path, suffix=".json")
         self._replace_in_files(
             test_paths,
             [
@@ -211,9 +241,9 @@ class TemplateRust(Template):
             data = utils.read_json_file(file)
             # Patch fields
             data["name"] = data.get("name", "").replace(self.template_name, self.project_name)
-            utils.write_json_file(file, data)
+            utils.write_json_file(str(file), data)
 
-    def _replace_in_files(self, files: List[Path], replacements, ignore_missing: bool) -> None:
+    def _replace_in_files(self, files: List[Path], replacements: List[Tuple[str, str]], ignore_missing: bool) -> None:
         for file in files:
             if ignore_missing and not file.exists():
                 continue

--- a/erdpy/testnet/wallets.py
+++ b/erdpy/testnet/wallets.py
@@ -74,11 +74,11 @@ def _get_observers_folder():
 
 
 def get_users() -> Dict[str, Account]:
-    result = OrderedDict()
+    result: Dict[str, Account] = OrderedDict()
 
     for pem_file in sorted(utils.list_files(_get_users_folder(), ".pem")):
         nickname = Path(pem_file).stem
-        account = Account(pem_file=pem_file)
+        account = Account(pem_file=str(pem_file))
         result[nickname] = account
 
     return result

--- a/erdpy/utils.py
+++ b/erdpy/utils.py
@@ -182,12 +182,11 @@ def find_in_dictionary(dictionary, compound_path):
     return node
 
 
-def list_files(folder: Union[str, Path], suffix: Optional[str] = None) -> List[str]:
-    files = os.listdir(folder)
-    files = [os.path.join(folder, f) for f in files]
+def list_files(folder: Path, suffix: Optional[str] = None) -> List[Path]:
+    files: List[Path] = [folder / f for f in os.listdir(folder)]
 
     if suffix:
-        files = [e for e in files if e.lower().endswith(suffix.lower())]
+        files = [e for e in files if str(e).lower().endswith(suffix.lower())]
 
     return files
 


### PR DESCRIPTION
On `erdpy contract new --template=foobar`, also copy the _erdjs snippets_ associated with the template `foobar` to a folder called `erdjs-snippets` (sibling of the contract folder).