### PR TITLE
Pin cryptography

### DIFF
--- a/erdpy/CHANGELOG.md
+++ b/erdpy/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
  - TBD
 
+## [1.3.3]
+ - [Pin cryptography](https://github.com/ElrondNetwork/elrond-sdk-erdpy/pull/137)
+
 ## [1.3.2]
  - [Do not copy test wallets into the newly created contract (not necessary anymore)](https://github.com/ElrondNetwork/elrond-sdk-erdpy/pull/134)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,11 @@ requests~=2.24.0
 types-requests
 pynacl
 pycryptodomex
-cryptography>=3.2
+cryptography==36.0.2
 prettytable
 types-prettytable
 ledgercomm
+ledgercomm[hid]
 semver
 requests-cache
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ cryptography==36.0.2
 prettytable
 types-prettytable
 ledgercomm
-ledgercomm[hid]
 semver
 requests-cache
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
         "cryptography==36.0.2",
         "prettytable",
         "ledgercomm",
-        "ledgercomm[hid]",
         "semver",
         "requests-cache"
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,10 @@ setuptools.setup(
         "requests",
         "pynacl",
         "pycryptodomex",
-        "cryptography>=3.2",
+        "cryptography==36.0.2",
         "prettytable",
         "ledgercomm",
+        "ledgercomm[hid]",
         "semver",
         "requests-cache"
     ],


### PR DESCRIPTION
- Compilation issue in https://github.com/ElrondNetwork/sc-savings-account-rs/pull/13
  - Caused by the latest version of cryptography (hint from https://github.com/nextstrain/cli/issues/171 )
- Pin `cryptography` to `36.0.2`, which was the latest version that worked (as `37.0.0` causes the issue)
- Tested fix in https://github.com/ElrondNetwork/sc-savings-account-rs/pull/14
- Postponed adding `ledgercomm[hid]` to another PR since the syntax is not trivial

Full exception log:
```
Traceback (most recent call last):
  File "/home/runner/.local/bin/erdpy", line 5, in <module>
    from erdpy.cli import main
  File "/home/runner/.local/lib/python3.8/site-packages/erdpy/cli.py", line 7, in <module>
    import erdpy.cli_accounts
  File "/home/runner/.local/lib/python3.8/site-packages/erdpy/cli_accounts.py", line 4, in <module>
    from erdpy import cli_shared, utils
  File "/home/runner/.local/lib/python3.8/site-packages/erdpy/cli_shared.py", line 7, in <module>
    from erdpy import config, errors, scope, utils
  File "/home/runner/.local/lib/python3.8/site-packages/erdpy/config.py", line 6, in <module>
    from erdpy import errors, utils, workstation
  File "/home/runner/.local/lib/python3.8/site-packages/erdpy/utils.py", line 8, in <module>
    import requests_cache
  File "/home/runner/.local/lib/python3.8/site-packages/requests_cache/__init__.py", line 11, in <module>
    from .backends import *
  File "/home/runner/.local/lib/python3.8/site-packages/requests_cache/backends/__init__.py", line 7, in <module>
    from .base import BaseCache, BaseStorage, DictStorage
  File "/home/runner/.local/lib/python3.8/site-packages/requests_cache/backends/base.py", line 15, in <module>
    from ..cache_control import ExpirationTime
  File "/home/runner/.local/lib/python3.8/site-packages/requests_cache/cache_control.py", line 21, in <module>
    from requests import PreparedRequest, Response
  File "/usr/lib/python3/dist-packages/requests/__init__.py", line 95, in <module>
    from urllib3.contrib import pyopenssl
  File "/usr/lib/python3/dist-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1553, in <module>
    class X509StoreFlags(object):
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```