### PR TITLE
Show password prompt if no passfile specificied

### DIFF
--- a/erdpy/accounts.py
+++ b/erdpy/accounts.py
@@ -11,7 +11,7 @@ from erdpy.ledger.ledger_app_handler import SIGN_USING_HASH_VERSION
 from erdpy.ledger.ledger_functions import do_get_ledger_address, do_sign_transaction_with_ledger, do_get_ledger_version, \
     TX_HASH_SIGN_VERSION, TX_HASH_SIGN_OPTIONS
 from erdpy.wallet import bech32, pem
-from erdpy.wallet.keyfile import get_password, load_from_key_file
+from erdpy.wallet.keyfile import load_from_key_file
 
 logger = logging.getLogger("accounts")
 
@@ -22,7 +22,7 @@ class Account(IAccount):
                  pem_file: Optional[str] = None,
                  pem_index: int = 0,
                  key_file: str = "",
-                 pass_file: str = "",
+                 password: str = "",
                  ledger: bool = False):
         self.address = Address(address)
         self.pem_file = pem_file
@@ -34,8 +34,7 @@ class Account(IAccount):
             secret_key, pubkey = pem.parse(Path(self.pem_file), self.pem_index)
             self.secret_key = secret_key.hex()
             self.address = Address(pubkey)
-        elif key_file and pass_file:
-            password = get_password(pass_file)
+        elif key_file and password:
             address_from_key_file, secret_key = load_from_key_file(key_file, password)
             self.secret_key = secret_key.hex()
             self.address = Address(address_from_key_file)

--- a/erdpy/cli_contracts.py
+++ b/erdpy/cli_contracts.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from erdpy import cli_shared, errors, projects, utils
 from erdpy.accounts import Account, Address, LedgerAccount
 from erdpy.cli_output import CLIOutputBuilder
+from erdpy.cli_password import load_password
 from erdpy.contracts import CodeMetadata, SmartContract
 from erdpy.projects import load_project
 from erdpy.projects.core import get_project_paths_recursively
@@ -284,8 +285,9 @@ def _prepare_sender(args: Any) -> Account:
         sender = LedgerAccount(account_index=args.ledger_account_index, address_index=args.ledger_address_index)
     elif args.pem:
         sender = Account(pem_file=args.pem, pem_index=args.pem_index)
-    elif args.keyfile and args.passfile:
-        sender = Account(key_file=args.keyfile, pass_file=args.passfile)
+    elif args.keyfile:
+        password = load_password(args)
+        sender = Account(key_file=args.keyfile, password=password)
     else:
         raise errors.NoWalletProvided()
 

--- a/erdpy/cli_password.py
+++ b/erdpy/cli_password.py
@@ -1,0 +1,7 @@
+from getpass import getpass
+
+def load_password(args):
+    if args.passfile:
+        with open(args.passfile) as pass_file:
+            return pass_file.read().strip()
+    return getpass("Keyfile's password: ")

--- a/erdpy/cli_shared.py
+++ b/erdpy/cli_shared.py
@@ -7,6 +7,7 @@ from typing import Any, List, Text, cast
 from erdpy import config, errors, scope, utils
 from erdpy.accounts import Account
 from erdpy.cli_output import CLIOutputBuilder
+from erdpy.cli_password import load_password
 from erdpy.ledger.ledger_functions import do_get_ledger_address
 from erdpy.proxy.core import ElrondProxy
 from erdpy.simulation import Simulator
@@ -80,7 +81,7 @@ def add_wallet_args(args: List[str], sub: Any):
     sub.add_argument("--pem", required=check_if_sign_method_required(args, "--pem"), help="🔑 the PEM file, if keyfile not provided")
     sub.add_argument("--pem-index", default=0, help="🔑 the index in the PEM file (default: %(default)s)")
     sub.add_argument("--keyfile", required=check_if_sign_method_required(args, "--keyfile"), help="🔑 a JSON keyfile, if PEM not provided")
-    sub.add_argument("--passfile", required=(utils.is_arg_present(args, "--keyfile")), help="🔑 a file containing keyfile's password, if keyfile provided")
+    sub.add_argument("--passfile", help="🔑 a file containing keyfile's password, if keyfile provided")
     sub.add_argument("--ledger", action="store_true", required=check_if_sign_method_required(args, "--ledger"), default=False, help="🔐 bool flag for signing transaction using ledger")
     sub.add_argument("--ledger-account-index", type=int, default=0, help="🔐 the index of the account when using Ledger")
     sub.add_argument("--ledger-address-index", type=int, default=0, help="🔐 the index of the address when using Ledger")
@@ -115,8 +116,9 @@ def prepare_nonce_in_args(args: Any):
     if args.recall_nonce:
         if args.pem:
             account = Account(pem_file=args.pem, pem_index=args.pem_index)
-        elif args.keyfile and args.passfile:
-            account = Account(key_file=args.keyfile, pass_file=args.passfile)
+        elif args.keyfile:
+            password = load_password(args)
+            account = Account(key_file=args.keyfile, password=password)
         elif args.ledger:
             address = do_get_ledger_address(account_index=args.ledger_account_index, address_index=args.ledger_address_index)
             account = Account(address=address)

--- a/erdpy/delegation/staking_provider.py
+++ b/erdpy/delegation/staking_provider.py
@@ -2,9 +2,10 @@ import binascii
 from pathlib import Path
 from typing import Any
 
-from erdpy.validators.validators_file import ValidatorsFile
 from erdpy import utils
+from erdpy.validators.validators_file import ValidatorsFile
 from erdpy.accounts import Account
+from erdpy.cli_password import load_password
 from erdpy.config import MetaChainSystemSCsCost
 from erdpy.validators.core import estimate_system_sc_call
 from erdpy.wallet.pem import parse_validator_pem
@@ -34,8 +35,9 @@ def prepare_args_for_add_nodes(args: Any):
         account = Account(address=args.delegation_contract)
     elif args.pem:
         account = Account(pem_file=args.pem)
-    elif args.keyfile and args.passfile:
-        account = Account(key_file=args.keyfile, pass_file=args.passfile)
+    elif args.keyfile:
+        password = load_password(args)
+        account = Account(key_file=args.keyfile, password=password)
 
     add_nodes_data = "addNodes"
     num_of_nodes = validators_file.get_num_of_nodes()

--- a/erdpy/transactions.py
+++ b/erdpy/transactions.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, TextIO
 
 from erdpy import config, errors, utils
 from erdpy.accounts import Account, Address, LedgerAccount
+from erdpy.cli_password import load_password
 from erdpy.interfaces import IElrondProxy, ITransaction, ITransactionOnNetwork
 
 logger = logging.getLogger("transactions")
@@ -211,8 +212,9 @@ def do_prepare_transaction(args: Any) -> Transaction:
         account = LedgerAccount(account_index=args.ledger_account_index, address_index=args.ledger_address_index)
     if args.pem:
         account = Account(pem_file=args.pem, pem_index=args.pem_index)
-    elif args.keyfile and args.passfile:
-        account = Account(key_file=args.keyfile, pass_file=args.passfile)
+    elif args.keyfile:
+        password = load_password(args)
+        account = Account(key_file=args.keyfile, password=password)
 
     tx = Transaction()
     tx.nonce = int(args.nonce)

--- a/erdpy/validators/core.py
+++ b/erdpy/validators/core.py
@@ -2,11 +2,12 @@ import logging
 from os import path
 from pathlib import Path
 from typing import Any, List, Tuple, Union
-from erdpy.contracts import SmartContract
-from erdpy.errors import BadUsage
 
-from erdpy.validators.validators_file import ValidatorsFile
 from erdpy import utils
+from erdpy.contracts import SmartContract
+from erdpy.cli_password import load_password
+from erdpy.errors import BadUsage
+from erdpy.validators.validators_file import ValidatorsFile
 from erdpy.accounts import Account, Address
 from erdpy.config import MetaChainSystemSCsCost, MIN_GAS_LIMIT, GAS_PER_DATA_BYTE
 from erdpy.wallet.pem import parse_validator_pem
@@ -24,8 +25,9 @@ def prepare_args_for_stake(args: Any):
 
     if args.pem:
         node_operator = Account(pem_file=args.pem)
-    elif args.keyfile and args.passfile:
-        node_operator = Account(key_file=args.keyfile, pass_file=args.passfile)
+    elif args.keyfile:
+        password = load_password(args)
+        node_operator = Account(key_file=args.keyfile, password=password)
     else:
         raise BadUsage("cannot initialize node operator")
 

--- a/erdpy/wallet/keyfile.py
+++ b/erdpy/wallet/keyfile.py
@@ -129,8 +129,3 @@ def format_key_json(uid: str, pubkey: str, iv: bytes, ciphertext: bytes, salt: b
             'mac': hexlify(mac).decode(),
         }
     }
-
-
-def get_password(pass_file):
-    with open(pass_file) as pass_f:
-        return pass_f.read().strip()

--- a/examples/staking.py
+++ b/examples/staking.py
@@ -1,9 +1,10 @@
 import logging
 from argparse import ArgumentParser
-from erdpy import utils
 
+from erdpy import utils
 from erdpy.accounts import Account, Address
 from erdpy.cli_output import CLIOutputBuilder
+from erdpy.cli_password import load_password
 from erdpy.proxy.core import ElrondProxy
 from erdpy.transactions import Transaction
 from erdpy.validators.core import VALIDATORS_SMART_CONTRACT_ADDRESS, prepare_transaction_data_for_stake
@@ -28,7 +29,7 @@ def main():
     parser = ArgumentParser()
     parser.add_argument("--proxy", required=True)
     parser.add_argument("--keyfile", help="wallet JSON keyfile", required=True)
-    parser.add_argument("--passfile", help="wallet password file", required=True)
+    parser.add_argument("--passfile", help="wallet keyfile's password file")
     parser.add_argument("--reward-address", required=True, help="the reward address")
     parser.add_argument("--validators-file", required=True, help="validators JSON file (with links to validator PEM files)")
     parser.add_argument("--value", type=int, required=True, help="value, as a number (atoms of EGLD)")
@@ -36,7 +37,8 @@ def main():
 
     proxy = ElrondProxy(args.proxy)
     network = proxy.get_network_config()
-    node_operator = Account(key_file=args.keyfile, pass_file=args.passfile)
+    password = load_password(args)
+    node_operator = Account(key_file=args.keyfile, password=password)
     node_operator.sync_nonce(proxy)
     reward_address = Address(args.reward_address)
     data, gas_limit = prepare_transaction_data_for_stake(node_operator.address, args.validators_file, reward_address)


### PR DESCRIPTION
Closes https://github.com/ElrondNetwork/elrond-sdk-erdpy/issues/66

Make --passfile argument optional. When a keyfile is specified without a corresponding passfile, a prompt will be shown asking for keyfile's password. Developers won't have to save the password on disk anymore.

Possible breaking change when using erdpy as a library: constructor of Account has been adjusted to take as input the keyfile's password directly, instead of the path of file containing the password.