### PR TITLE
Fix test replacement rules

### DIFF
--- a/erdpy/projects/templates.py
+++ b/erdpy/projects/templates.py
@@ -212,7 +212,7 @@ class TemplateRust(Template):
                 (f"extern crate {template_name};", f"extern crate {project_name};"),
                 # Example: replace "empty::ContractObj" to "foo_bar::ContractObj"
                 (f"{template_name}::ContractObj", f"{project_name}::ContractObj"),
-                # Example: replace "empty::contract_obj" to "foo_bar::contract_obj"
+                (f"{template_name}::ContractBuilder", f"{project_name}::ContractBuilder"),
                 (f"{template_name}::contract_obj", f"{project_name}::contract_obj"),
             ],
             ignore_missing

--- a/erdpy/projects/templates.py
+++ b/erdpy/projects/templates.py
@@ -210,6 +210,10 @@ class TemplateRust(Template):
                 (f"<{template_name}::AbiProvider>()", f"<{project_name}::AbiProvider>()"),
                 # Example: replace "extern crate adder;" to "extern crate myadder;"
                 (f"extern crate {template_name};", f"extern crate {project_name};"),
+                # Example: replace "empty::ContractObj" to "foo_bar::ContractObj"
+                (f"{template_name}::ContractObj", f"{project_name}::ContractObj"),
+                # Example: replace "empty::contract_obj" to "foo_bar::contract_obj"
+                (f"{template_name}::contract_obj", f"{project_name}::contract_obj"),
             ],
             ignore_missing
         )


### PR DESCRIPTION
When creating a new project from a template, the tests do not compile properly because the old project name was not replaced with the new one in all cases.
Tested locally.