### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/erdpy.yml
+++ b/.github/workflows/erdpy.yml
@@ -65,6 +65,7 @@ jobs:
         pytest .
     - name: Run CLI tests
       run: |
+        python3 -m erdpy.cli config set dependencies.vmtools.tag v1.4.53
         cd ./erdpy/tests
         source ./test_cli_contracts.sh && testAll || return 1
         source ./test_cli_wallet.sh && testAll || return 1


### PR DESCRIPTION
Fixes the github actions tests which failed because the vmtools version used was the latest (1.5.0) instead of the same one used by the elrond-wasm-rs repository (1.4.53).
Fixed by setting the dependency config. The vmtools is automatically downloaded by the `${ERDPY} --verbose contract test` command in `test_cli_contracts.sh`.