### PR TITLE
Remove ubuntu 18.04 from github actions matrix

### DIFF
--- a/.github/workflows/erdpy.yml
+++ b/.github/workflows/erdpy.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.8]
 
     steps:


### PR DESCRIPTION
Remove the ubuntu 18.04 image since it is being deprecated.
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/