### PR TITLE
update erdpy.yml

### DIFF
--- a/.github/workflows/erdpy.yml
+++ b/.github/workflows/erdpy.yml
@@ -49,6 +49,11 @@ jobs:
         python3 -m pip install --upgrade pip
         pip3 install -r requirements.txt
         pip3 install pytest
+    - name: Install libtinfo5
+      if: ${{ matrix.os != 'macos-latest' }}
+      run: |
+        sudo apt update
+        sudo apt install -y libtinfo5
     - name: Set github_api_token
       run: |
         mkdir ~/elrondsdk


### PR DESCRIPTION
- `libtinfo5` needed for latest ubuntu os version, fails for latest macos version.