### PR TITLE
Reproducible builds endpoint for erdpy cli

### DIFF
--- a/erdpy/cli_contracts.py
+++ b/erdpy/cli_contracts.py
@@ -373,10 +373,10 @@ def _send_or_simulate(tx: Transaction, contract: SmartContract, args: Any):
 
 
 def reproduce_build(args: Any):
-    project_path = get_project_paths(args)
+    project_paths = get_project_paths(args)
 
-    if len(project_path) == 1:
-        project_path = project_path[0].expanduser().resolve()
+    if len(project_paths) == 1:
+        project_path = project_paths[0].expanduser().resolve()
     else:
         raise NotImplementedError()
 

--- a/erdpy/docker.py
+++ b/erdpy/docker.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+from pathlib import Path
+from typing import Union, List
+from erdpy.errors import DockerError
+
+
+def is_docker_installed():
+    try:
+        result = subprocess.run(["docker", "--version"], capture_output=True, text=True)
+        output = result.stdout
+    
+        if "Docker version" in output:
+            return True
+        else:
+            raise DockerError()
+    except:
+        print("Something went wrong when checking if docker is installed!")
+
+
+def run_docker(image: str, project_path: Union[Path, None], contract_path: str, output_path: Path,
+                cargo_target_dir: Union[Path, None], no_wasm_opt: bool):
+    docker_mount_args: List[str] = ["--volume", f"{output_path}:/output"]
+
+    if project_path:
+        docker_mount_args.extend(["--volume", f"{project_path}:/project"])
+
+    if cargo_target_dir:
+        docker_mount_args += ["--volume", f"{cargo_target_dir}:/cargo-target-dir"]
+
+    docker_args = ["docker", "run"]
+
+    docker_args += ["--interactive"]
+    docker_args += ["--tty"]
+    docker_args += docker_mount_args
+    docker_args += ["--user", f"{str(os.getuid())}:{str(os.getgid())}"]
+    docker_args += ["--rm", image]
+
+    entrypoint_args: List[str] = []
+
+    if project_path:
+        entrypoint_args.extend(["--project", "project"])
+
+    if no_wasm_opt:
+        entrypoint_args.append("--no-wasm-opt")
+
+    if contract_path:
+        entrypoint_args.extend(["--contract", contract_path])
+
+    args = docker_args + entrypoint_args
+
+    result = subprocess.run(args)
+
+    return result.returncode

--- a/erdpy/docker.py
+++ b/erdpy/docker.py
@@ -3,7 +3,6 @@ import logging
 import subprocess
 from pathlib import Path
 from typing import List
-from erdpy.errors import DockerMissingError
 
 
 logger = logging.getLogger("build-with-docker")
@@ -17,7 +16,7 @@ def is_docker_installed():
         if "Docker version" in output:
             return True
         else:
-            raise DockerMissingError()
+            return False
     except:
         logger.error("Something went wrong when checking if docker is installed!")
 
@@ -27,7 +26,6 @@ def run_docker(image: str, project_path: Path, contract: str, output_path: Path,
 
     if project_path:
         docker_mount_args.extend(["--volume", f"{project_path}:/project"])
-
 
     docker_args = ["docker", "run"]
 

--- a/erdpy/errors.py
+++ b/erdpy/errors.py
@@ -188,3 +188,8 @@ class TestnetError(KnownError):
 class LedgerError(KnownError):
     def __init__(self, message: str):
         super().__init__("Ledger error: " + message)
+
+
+class DockerError(KnownError):
+    def __init__(self):
+        super().__init__("Docker is not installed! Please visit https://docs.docker.com/get-docker/ to install docker.")

--- a/erdpy/errors.py
+++ b/erdpy/errors.py
@@ -190,6 +190,6 @@ class LedgerError(KnownError):
         super().__init__("Ledger error: " + message)
 
 
-class DockerError(KnownError):
+class DockerMissingError(KnownError):
     def __init__(self):
         super().__init__("Docker is not installed! Please visit https://docs.docker.com/get-docker/ to install docker.")

--- a/erdpy/tests/test_cli_contracts.sh
+++ b/erdpy/tests/test_cli_contracts.sh
@@ -120,6 +120,13 @@ testCleanContracts() {
     assertFileDoesNotExist ${SANDBOX}/myfunding-rs/output/myfunding-rs.abi.json || return 1
 }
 
+testReproducibleBuild(){
+    echo "testReproducibleBuild"
+
+    ${ERDPY} contract reproducible-build ${SANDBOX}/ping-pong-smart-contract --contract=ping-pong --docker-image=elrondnetwork/build-contract-rust:v4.0.0
+    assertFileExists ${SANDBOX}/ping-pong-smart-contract/output-docker/ping-pong/ping-pong.wasm || return 1
+}
+
 testAll() {
     cleanSandbox || return 1
     testTrivialCommands || return 1


### PR DESCRIPTION
Added a new endpoint called `reproducible-build` for erdpy cli.
The purpose of this endpoint is to reproduce a previously built Smart Contract using a Docker image.
The command can be used as easy as: **erdpy contract reproducible-build [project-path] --contract=[contract-name] 
--docker-image=[docker-image]**.
Build with docker implementation: https://github.com/ElrondNetwork/elrond-sdk-images-build-contract-rust/blob/main/build_with_docker.py
Also added a test.